### PR TITLE
Add streamed multipart uploads for large storage files(#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ let autoFile = try await client.storage
         fileName: "profile.jpg"
     )
 
+// Upload a large local file without loading the entire multipart body into memory
+let videoURL = URL(fileURLWithPath: "/tmp/demo.mov")
+let streamedFile = try await client.storage
+    .from("avatars")
+    .upload(
+        path: "videos/demo.mov",
+        fileURL: videoURL,
+        options: FileOptions(contentType: "video/quicktime", multipartChunkSize: 512 * 1024)
+    )
+
 // Download a file
 let data = try await client.storage
     .from("avatars")

--- a/Sources/Core/HTTPClient.swift
+++ b/Sources/Core/HTTPClient.swift
@@ -210,7 +210,7 @@ public actor HTTPClient {
         fileURL: URL,
         fileName: String,
         mimeType: String,
-        chunkSize: Int = 1_048_576
+        chunkSize: Int = MultipartFormBodyFile.defaultChunkSize
     ) async throws -> HTTPResponse {
         let bodyFile = try MultipartFormBodyFile.create(
             formFields: formFields,
@@ -357,7 +357,7 @@ public actor HTTPClient {
         fileURL: URL,
         fileName: String,
         mimeType: String,
-        chunkSize: Int = 1_048_576,
+        chunkSize: Int = MultipartFormBodyFile.defaultChunkSize,
         refreshHandler: TokenRefreshHandler
     ) async throws -> HTTPResponse {
         do {

--- a/Sources/Core/HTTPClient.swift
+++ b/Sources/Core/HTTPClient.swift
@@ -190,6 +190,45 @@ public actor HTTPClient {
         return httpResponseObj
     }
 
+    /// Uploads multipart form data from disk without loading the entire request body into memory.
+    /// - Parameters:
+    ///   - url: The URL to upload to.
+    ///   - method: The HTTP method to use. Defaults to `.put`.
+    ///   - headers: Optional HTTP headers. Defaults to empty.
+    ///   - formFields: Additional multipart fields to include before the file part.
+    ///   - fileURL: The file URL to upload.
+    ///   - fileName: The filename to present in the multipart body.
+    ///   - mimeType: The MIME type of the file.
+    ///   - chunkSize: The chunk size to use while building the streamed multipart body.
+    /// - Returns: An `HTTPResponse` containing the response data.
+    /// - Throws: `InsForgeError` if the upload fails.
+    public func uploadMultipartForm(
+        url: URL,
+        method: HTTPMethod = .put,
+        headers: [String: String] = [:],
+        formFields: [String: String] = [:],
+        fileURL: URL,
+        fileName: String,
+        mimeType: String,
+        chunkSize: Int = 1_048_576
+    ) async throws -> HTTPResponse {
+        let bodyFile = try MultipartFormBodyFile.create(
+            formFields: formFields,
+            sourceFileURL: fileURL,
+            fileName: fileName,
+            mimeType: mimeType,
+            chunkSize: chunkSize
+        )
+        defer { bodyFile.cleanup() }
+
+        return try await uploadMultipartBodyFile(
+            url: url,
+            method: method,
+            headers: headers,
+            bodyFile: bodyFile
+        )
+    }
+
     // MARK: - Auto-Refresh Execution
 
     /// Executes an HTTP request with automatic token refresh on 401 errors.
@@ -294,6 +333,128 @@ public actor HTTPClient {
 
             // Not a 401 error, re-throw original error
             throw error
+        }
+    }
+
+    /// Uploads multipart form data from disk with automatic token refresh on 401 errors.
+    /// - Parameters:
+    ///   - url: The URL to upload to.
+    ///   - method: The HTTP method to use. Defaults to `.put`.
+    ///   - headers: HTTP headers. The Authorization header will be updated with refreshed token.
+    ///   - formFields: Additional multipart fields to include before the file part.
+    ///   - fileURL: The file URL to upload.
+    ///   - fileName: The filename to present in the multipart body.
+    ///   - mimeType: The MIME type of the file.
+    ///   - chunkSize: The chunk size to use while building the streamed multipart body.
+    ///   - refreshHandler: The handler responsible for refreshing the token.
+    /// - Returns: An `HTTPResponse` containing the response data.
+    /// - Throws: `InsForgeError` if the upload fails after retry, or if token refresh fails.
+    public func uploadMultipartFormWithAutoRefresh(
+        url: URL,
+        method: HTTPMethod = .put,
+        headers: [String: String],
+        formFields: [String: String] = [:],
+        fileURL: URL,
+        fileName: String,
+        mimeType: String,
+        chunkSize: Int = 1_048_576,
+        refreshHandler: TokenRefreshHandler
+    ) async throws -> HTTPResponse {
+        do {
+            return try await uploadMultipartForm(
+                url: url,
+                method: method,
+                headers: headers,
+                formFields: formFields,
+                fileURL: fileURL,
+                fileName: fileName,
+                mimeType: mimeType,
+                chunkSize: chunkSize
+            )
+        } catch let error as InsForgeError {
+            if case .httpError(let statusCode, _, _, _) = error, statusCode == 401 {
+                logger.debug("Received 401 during multipart upload, attempting token refresh...")
+
+                do {
+                    let newToken = try await refreshHandler.refreshToken()
+                    logger.debug("Token refreshed successfully, retrying multipart upload...")
+
+                    var updatedHeaders = headers
+                    updatedHeaders["Authorization"] = "Bearer \(newToken)"
+
+                    return try await uploadMultipartForm(
+                        url: url,
+                        method: method,
+                        headers: updatedHeaders,
+                        formFields: formFields,
+                        fileURL: fileURL,
+                        fileName: fileName,
+                        mimeType: mimeType,
+                        chunkSize: chunkSize
+                    )
+                } catch {
+                    logger.error("Token refresh failed during multipart upload: \(error)")
+                    throw InsForgeError.authenticationRequired
+                }
+            }
+
+            throw error
+        }
+    }
+
+    private func uploadMultipartBodyFile(
+        url: URL,
+        method: HTTPMethod,
+        headers: [String: String],
+        bodyFile: MultipartFormBodyFile
+    ) async throws -> HTTPResponse {
+        var request = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+        guard let stream = InputStream(url: bodyFile.fileURL) else {
+            throw InsForgeError.unknown("Failed to open upload body stream")
+        }
+        request.httpBodyStream = stream
+
+        var allHeaders = headers
+        allHeaders["Content-Type"] = "multipart/form-data; boundary=\(bodyFile.boundary)"
+        allHeaders["Content-Length"] = String(bodyFile.contentLength)
+
+        for (key, value) in allHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+
+        logger.debug("[UPLOAD-\(method.rawValue)] \(url)")
+
+        do {
+            let (data, response) = try await session.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw InsForgeError.invalidResponse
+            }
+
+            logger.debug("Upload response status: \(httpResponse.statusCode)")
+
+            let httpResponseObj = HTTPResponse(
+                data: data,
+                response: httpResponse
+            )
+
+            if !(200..<300).contains(httpResponse.statusCode) {
+                let error = try? JSONDecoder().decode(ErrorResponse.self, from: data)
+                throw InsForgeError.httpError(
+                    statusCode: httpResponse.statusCode,
+                    message: error?.message ?? "Upload failed",
+                    error: error?.error,
+                    nextActions: error?.nextActions
+                )
+            }
+
+            return httpResponseObj
+        } catch let error as InsForgeError {
+            throw error
+        } catch {
+            logger.error("Network error: \(error)")
+            throw InsForgeError.networkError(error)
         }
     }
 }

--- a/Sources/Core/MultipartFormBodyFile.swift
+++ b/Sources/Core/MultipartFormBodyFile.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+struct MultipartFormBodyFile: Sendable {
+    static let defaultChunkSize = 1_048_576
+
+    let fileURL: URL
+    let boundary: String
+    let contentLength: UInt64
+
+    static func create(
+        formFields: [String: String],
+        sourceFileURL: URL,
+        fileName: String,
+        mimeType: String,
+        chunkSize: Int = defaultChunkSize
+    ) throws -> MultipartFormBodyFile {
+        guard chunkSize > 0 else {
+            throw InsForgeError.validationError("Chunk size must be greater than 0")
+        }
+
+        let boundary = "InsForgeBoundary-\(UUID().uuidString)"
+        let tempFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("insforge-multipart-\(UUID().uuidString)")
+
+        guard FileManager.default.createFile(atPath: tempFileURL.path, contents: nil) else {
+            throw InsForgeError.unknown("Failed to create temporary upload body file")
+        }
+
+        let outputHandle = try FileHandle(forWritingTo: tempFileURL)
+        defer { try? outputHandle.close() }
+
+        for (key, value) in formFields {
+            try outputHandle.write(contentsOf: Data("--\(boundary)\r\n".utf8))
+            try outputHandle.write(contentsOf: Data("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".utf8))
+            try outputHandle.write(contentsOf: Data("\(value)\r\n".utf8))
+        }
+
+        try outputHandle.write(contentsOf: Data("--\(boundary)\r\n".utf8))
+        try outputHandle.write(contentsOf: Data("Content-Disposition: form-data; name=\"file\"; filename=\"\(fileName)\"\r\n".utf8))
+        try outputHandle.write(contentsOf: Data("Content-Type: \(mimeType)\r\n\r\n".utf8))
+
+        let inputHandle = try FileHandle(forReadingFrom: sourceFileURL)
+        defer { try? inputHandle.close() }
+
+        while true {
+            let chunk = inputHandle.readData(ofLength: chunkSize)
+            if chunk.isEmpty {
+                break
+            }
+            try outputHandle.write(contentsOf: chunk)
+        }
+
+        try outputHandle.write(contentsOf: Data("\r\n--\(boundary)--\r\n".utf8))
+        try outputHandle.synchronize()
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: tempFileURL.path)
+        let fileSize = attributes[.size] as? NSNumber
+
+        return MultipartFormBodyFile(
+            fileURL: tempFileURL,
+            boundary: boundary,
+            contentLength: fileSize?.uint64Value ?? 0
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+}

--- a/Sources/Core/MultipartFormBodyFile.swift
+++ b/Sources/Core/MultipartFormBodyFile.swift
@@ -26,18 +26,32 @@ struct MultipartFormBodyFile: Sendable {
             throw InsForgeError.unknown("Failed to create temporary upload body file")
         }
 
+        var shouldCleanupTemporaryFile = true
+        defer {
+            if shouldCleanupTemporaryFile {
+                try? FileManager.default.removeItem(at: tempFileURL)
+            }
+        }
+
         let outputHandle = try FileHandle(forWritingTo: tempFileURL)
         defer { try? outputHandle.close() }
 
-        for (key, value) in formFields {
-            try outputHandle.write(contentsOf: Data("--\(boundary)\r\n".utf8))
-            try outputHandle.write(contentsOf: Data("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".utf8))
-            try outputHandle.write(contentsOf: Data("\(value)\r\n".utf8))
+        var contentLength: UInt64 = 0
+
+        func write(_ data: Data) throws {
+            try outputHandle.write(contentsOf: data)
+            contentLength += UInt64(data.count)
         }
 
-        try outputHandle.write(contentsOf: Data("--\(boundary)\r\n".utf8))
-        try outputHandle.write(contentsOf: Data("Content-Disposition: form-data; name=\"file\"; filename=\"\(fileName)\"\r\n".utf8))
-        try outputHandle.write(contentsOf: Data("Content-Type: \(mimeType)\r\n\r\n".utf8))
+        for (key, value) in formFields {
+            try write(Data("--\(boundary)\r\n".utf8))
+            try write(Data("Content-Disposition: form-data; name=\"\(key)\"\r\n\r\n".utf8))
+            try write(Data("\(value)\r\n".utf8))
+        }
+
+        try write(Data("--\(boundary)\r\n".utf8))
+        try write(Data("Content-Disposition: form-data; name=\"file\"; filename=\"\(fileName)\"\r\n".utf8))
+        try write(Data("Content-Type: \(mimeType)\r\n\r\n".utf8))
 
         let inputHandle = try FileHandle(forReadingFrom: sourceFileURL)
         defer { try? inputHandle.close() }
@@ -47,19 +61,18 @@ struct MultipartFormBodyFile: Sendable {
             if chunk.isEmpty {
                 break
             }
-            try outputHandle.write(contentsOf: chunk)
+            try write(chunk)
         }
 
-        try outputHandle.write(contentsOf: Data("\r\n--\(boundary)--\r\n".utf8))
+        try write(Data("\r\n--\(boundary)--\r\n".utf8))
         try outputHandle.synchronize()
 
-        let attributes = try FileManager.default.attributesOfItem(atPath: tempFileURL.path)
-        let fileSize = attributes[.size] as? NSNumber
+        shouldCleanupTemporaryFile = false
 
         return MultipartFormBodyFile(
             fileURL: tempFileURL,
             boundary: boundary,
-            contentLength: fileSize?.uint64Value ?? 0
+            contentLength: contentLength
         )
     }
 

--- a/Sources/Storage/StorageClient.swift
+++ b/Sources/Storage/StorageClient.swift
@@ -6,18 +6,25 @@ import Logging
 
 /// Options for file upload operations
 public struct FileOptions: Sendable {
+    public static let defaultMultipartChunkSize = 1_048_576
+
     /// The `Content-Type` header value. If not specified, it will be inferred from the file.
     public var contentType: String?
 
     /// Optional extra headers for the request.
     public var headers: [String: String]?
 
+    /// Chunk size in bytes used when building streamed multipart uploads from local files.
+    public var multipartChunkSize: Int
+
     public init(
         contentType: String? = nil,
-        headers: [String: String]? = nil
+        headers: [String: String]? = nil,
+        multipartChunkSize: Int = FileOptions.defaultMultipartChunkSize
     ) {
         self.contentType = contentType
         self.headers = headers
+        self.multipartChunkSize = multipartChunkSize
     }
 }
 
@@ -431,7 +438,8 @@ public struct StorageFileApi: Sendable {
         return storedFile
     }
 
-    /// Uploads a file from a local file URL.
+    /// Uploads a file from a local file URL using a streamed multipart body to avoid
+    /// materializing the full upload request in memory.
     /// - Parameters:
     ///   - path: The object key.
     ///   - fileURL: The local file URL to upload.
@@ -443,8 +451,39 @@ public struct StorageFileApi: Sendable {
         fileURL: URL,
         options: FileOptions = FileOptions()
     ) async throws -> StoredFile {
-        let data = try Data(contentsOf: fileURL)
-        return try await upload(path: path, data: data, options: options)
+        let contentType = options.contentType ?? inferContentType(from: path)
+        let fileSize = try fileSize(at: fileURL)
+
+        let strategy = try await getUploadStrategy(
+            filename: path,
+            contentType: contentType,
+            size: fileSize
+        )
+
+        try await uploadToStrategy(
+            strategy: strategy,
+            fileURL: fileURL,
+            fileName: (path as NSString).lastPathComponent,
+            contentType: contentType,
+            chunkSize: options.multipartChunkSize
+        )
+
+        if strategy.confirmRequired {
+            let storedFile = try await confirmUpload(
+                path: strategy.key,
+                size: fileSize,
+                contentType: contentType
+            )
+            logger.debug("File uploaded to '\(path)' via streamed multipart upload")
+            return storedFile
+        }
+
+        let files = try await list(options: ListOptions(prefix: strategy.key, limit: 1))
+        guard let storedFile = files.first else {
+            throw InsForgeError.httpError(statusCode: 404, message: "Uploaded file not found", error: nil, nextActions: nil)
+        }
+        logger.debug("File uploaded to '\(path)' via streamed multipart upload")
+        return storedFile
     }
 
     /// Uploads a file with auto-generated key using presigned URL flow.
@@ -502,13 +541,71 @@ public struct StorageFileApi: Sendable {
             try await uploadWithPresignedFields(url: uploadURL, fields: fields, data: data, contentType: contentType)
         } else {
             // Direct upload
-            _ = try await httpClient.upload(
+            if let handler = tokenRefreshHandler {
+                _ = try await httpClient.uploadWithAutoRefresh(
+                    url: uploadURL,
+                    method: .post,
+                    headers: headers,
+                    file: data,
+                    fileName: strategy.key,
+                    mimeType: contentType,
+                    refreshHandler: handler
+                )
+            } else {
+                _ = try await httpClient.upload(
+                    url: uploadURL,
+                    method: .post,
+                    headers: headers,
+                    file: data,
+                    fileName: strategy.key,
+                    mimeType: contentType
+                )
+            }
+        }
+    }
+
+    /// Internal method to upload a local file to the strategy endpoint using a streamed multipart body.
+    private func uploadToStrategy(
+        strategy: UploadStrategy,
+        fileURL: URL,
+        fileName: String,
+        contentType: String,
+        chunkSize: Int
+    ) async throws {
+        guard let uploadURL = URL(string: strategy.uploadUrl) else {
+            throw InsForgeError.invalidURL
+        }
+
+        if strategy.method == "presigned", let fields = strategy.fields {
+            _ = try await httpClient.uploadMultipartForm(
+                url: uploadURL,
+                method: .post,
+                formFields: fields,
+                fileURL: fileURL,
+                fileName: fileName,
+                mimeType: contentType,
+                chunkSize: chunkSize
+            )
+        } else if let handler = tokenRefreshHandler {
+            _ = try await httpClient.uploadMultipartFormWithAutoRefresh(
                 url: uploadURL,
                 method: .post,
                 headers: headers,
-                file: data,
-                fileName: strategy.key,
-                mimeType: contentType
+                fileURL: fileURL,
+                fileName: fileName,
+                mimeType: contentType,
+                chunkSize: chunkSize,
+                refreshHandler: handler
+            )
+        } else {
+            _ = try await httpClient.uploadMultipartForm(
+                url: uploadURL,
+                method: .post,
+                headers: headers,
+                fileURL: fileURL,
+                fileName: fileName,
+                mimeType: contentType,
+                chunkSize: chunkSize
             )
         }
     }
@@ -907,5 +1004,19 @@ public struct StorageFileApi: Sendable {
         default:
             return "application/octet-stream"
         }
+    }
+
+    private func fileSize(at fileURL: URL) throws -> Int {
+        let resourceValues = try fileURL.resourceValues(forKeys: [.fileSizeKey])
+        if let fileSize = resourceValues.fileSize {
+            return fileSize
+        }
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        if let fileSize = attributes[.size] as? NSNumber {
+            return fileSize.intValue
+        }
+
+        throw InsForgeError.validationError("Unable to determine file size for upload")
     }
 }

--- a/Sources/Storage/StorageClient.swift
+++ b/Sources/Storage/StorageClient.swift
@@ -2,6 +2,10 @@ import Foundation
 import InsForgeCore
 import Logging
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 // MARK: - Options
 
 /// Options for file upload operations

--- a/Sources/Storage/StorageClient.swift
+++ b/Sources/Storage/StorageClient.swift
@@ -420,14 +420,15 @@ public struct StorageFileApi: Sendable {
         )
 
         // 2. Upload to presigned URL or direct endpoint
-        try await uploadToStrategy(strategy: strategy, data: data, contentType: contentType)
+        let etag = try await uploadToStrategy(strategy: strategy, data: data, contentType: contentType)
 
         // 3. Confirm upload if required
         if strategy.confirmRequired {
             let storedFile = try await confirmUpload(
                 path: strategy.key,
                 size: data.count,
-                contentType: contentType
+                contentType: contentType,
+                etag: etag
             )
             logger.debug("File uploaded to '\(path)' via presigned URL")
             return storedFile
@@ -464,7 +465,7 @@ public struct StorageFileApi: Sendable {
             size: fileSize
         )
 
-        try await uploadToStrategy(
+        let etag = try await uploadToStrategy(
             strategy: strategy,
             fileURL: fileURL,
             fileName: (path as NSString).lastPathComponent,
@@ -476,7 +477,8 @@ public struct StorageFileApi: Sendable {
             let storedFile = try await confirmUpload(
                 path: strategy.key,
                 size: fileSize,
-                contentType: contentType
+                contentType: contentType,
+                etag: etag
             )
             logger.debug("File uploaded to '\(path)' via streamed multipart upload")
             return storedFile
@@ -512,14 +514,15 @@ public struct StorageFileApi: Sendable {
         )
 
         // 2. Upload to presigned URL or direct endpoint
-        try await uploadToStrategy(strategy: strategy, data: data, contentType: contentType)
+        let etag = try await uploadToStrategy(strategy: strategy, data: data, contentType: contentType)
 
         // 3. Confirm upload if required
         if strategy.confirmRequired {
             let storedFile = try await confirmUpload(
                 path: strategy.key,
                 size: data.count,
-                contentType: contentType
+                contentType: contentType,
+                etag: etag
             )
             logger.debug("File uploaded with auto-generated key via presigned URL")
             return storedFile
@@ -535,18 +538,18 @@ public struct StorageFileApi: Sendable {
     }
 
     /// Internal method to upload data to the strategy endpoint
-    private func uploadToStrategy(strategy: UploadStrategy, data: Data, contentType: String) async throws {
+    private func uploadToStrategy(strategy: UploadStrategy, data: Data, contentType: String) async throws -> String? {
         guard let uploadURL = URL(string: strategy.uploadUrl) else {
             throw InsForgeError.invalidURL
         }
 
         if strategy.method == "presigned", let fields = strategy.fields {
             // S3 presigned POST - include all fields from strategy
-            try await uploadWithPresignedFields(url: uploadURL, fields: fields, data: data, contentType: contentType)
+            return try await uploadWithPresignedFields(url: uploadURL, fields: fields, data: data, contentType: contentType)
         } else {
             // Direct upload
             if let handler = tokenRefreshHandler {
-                _ = try await httpClient.uploadWithAutoRefresh(
+                let response = try await httpClient.uploadWithAutoRefresh(
                     url: uploadURL,
                     method: .post,
                     headers: headers,
@@ -555,8 +558,9 @@ public struct StorageFileApi: Sendable {
                     mimeType: contentType,
                     refreshHandler: handler
                 )
+                return normalizedETag(from: response)
             } else {
-                _ = try await httpClient.upload(
+                let response = try await httpClient.upload(
                     url: uploadURL,
                     method: .post,
                     headers: headers,
@@ -564,6 +568,7 @@ public struct StorageFileApi: Sendable {
                     fileName: strategy.key,
                     mimeType: contentType
                 )
+                return normalizedETag(from: response)
             }
         }
     }
@@ -575,13 +580,13 @@ public struct StorageFileApi: Sendable {
         fileName: String,
         contentType: String,
         chunkSize: Int
-    ) async throws {
+    ) async throws -> String? {
         guard let uploadURL = URL(string: strategy.uploadUrl) else {
             throw InsForgeError.invalidURL
         }
 
         if strategy.method == "presigned", let fields = strategy.fields {
-            _ = try await httpClient.uploadMultipartForm(
+            let response = try await httpClient.uploadMultipartForm(
                 url: uploadURL,
                 method: .post,
                 formFields: fields,
@@ -590,8 +595,9 @@ public struct StorageFileApi: Sendable {
                 mimeType: contentType,
                 chunkSize: chunkSize
             )
+            return normalizedETag(from: response)
         } else if let handler = tokenRefreshHandler {
-            _ = try await httpClient.uploadMultipartFormWithAutoRefresh(
+            let response = try await httpClient.uploadMultipartFormWithAutoRefresh(
                 url: uploadURL,
                 method: .post,
                 headers: headers,
@@ -601,8 +607,9 @@ public struct StorageFileApi: Sendable {
                 chunkSize: chunkSize,
                 refreshHandler: handler
             )
+            return normalizedETag(from: response)
         } else {
-            _ = try await httpClient.uploadMultipartForm(
+            let response = try await httpClient.uploadMultipartForm(
                 url: uploadURL,
                 method: .post,
                 headers: headers,
@@ -611,11 +618,12 @@ public struct StorageFileApi: Sendable {
                 mimeType: contentType,
                 chunkSize: chunkSize
             )
+            return normalizedETag(from: response)
         }
     }
 
     /// Upload to S3 using presigned POST with form fields
-    private func uploadWithPresignedFields(url: URL, fields: [String: String], data: Data, contentType: String) async throws {
+    private func uploadWithPresignedFields(url: URL, fields: [String: String], data: Data, contentType: String) async throws -> String? {
         let boundary = UUID().uuidString
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
@@ -660,6 +668,17 @@ public struct StorageFileApi: Sendable {
                 nextActions: nil
             )
         }
+
+        return normalizedETag(from: httpResponse)
+    }
+
+    private func normalizedETag(from response: HTTPResponse) -> String? {
+        normalizedETag(from: response.response)
+    }
+
+    private func normalizedETag(from response: HTTPURLResponse) -> String? {
+        response.value(forHTTPHeaderField: "ETag")?
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
     }
 
     // MARK: - Download

--- a/Tests/InsForgeStorageTests/StorageChunkedUploadTests.swift
+++ b/Tests/InsForgeStorageTests/StorageChunkedUploadTests.swift
@@ -104,7 +104,10 @@ final class StorageChunkedUploadTests: XCTestCase {
 
         let uploadRequest = try XCTUnwrap(capturedRequests.first { $0.url.absoluteString == "https://uploads.example.com/presigned" })
         XCTAssertNil(uploadRequest.request.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertNil(uploadRequest.request.httpBody)
+        XCTAssertNotNil(uploadRequest.request.httpBodyStream)
         XCTAssertTrue(uploadRequest.request.value(forHTTPHeaderField: "Content-Type")?.contains("multipart/form-data; boundary=") == true)
+        XCTAssertEqual(uploadRequest.request.value(forHTTPHeaderField: "Content-Length"), String(uploadRequest.body.count))
 
         let uploadBodyString = try XCTUnwrap(String(data: uploadRequest.body, encoding: .utf8))
         XCTAssertTrue(uploadBodyString.contains("name=\"key\"\r\n\r\nuploads/large-file.txt"))
@@ -142,6 +145,23 @@ final class StorageChunkedUploadTests: XCTestCase {
 
             XCTAssertEqual(message, "Chunk size must be greater than 0")
         }
+    }
+
+    func testMultipartBodyFileCleansUpTemporaryFileWhenCreationFails() {
+        let existingTempFiles = multipartBodyTempFiles()
+        let missingSourceFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-source-\(UUID().uuidString).txt")
+
+        XCTAssertThrowsError(
+            try MultipartFormBodyFile.create(
+                formFields: [:],
+                sourceFileURL: missingSourceFileURL,
+                fileName: "missing.txt",
+                mimeType: "text/plain"
+            )
+        )
+
+        XCTAssertEqual(multipartBodyTempFiles(), existingTempFiles)
     }
 }
 
@@ -215,7 +235,7 @@ private final class MockURLProtocol: URLProtocol {
         let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
         defer { buffer.deallocate() }
 
-        while stream.hasBytesAvailable {
+        while true {
             let read = stream.read(buffer, maxLength: bufferSize)
             if read > 0 {
                 data.append(buffer, count: read)
@@ -226,4 +246,18 @@ private final class MockURLProtocol: URLProtocol {
 
         return data
     }
+}
+
+private func multipartBodyTempFiles() -> Set<String> {
+    let temporaryDirectory = FileManager.default.temporaryDirectory
+    let temporaryFiles = (try? FileManager.default.contentsOfDirectory(
+        at: temporaryDirectory,
+        includingPropertiesForKeys: nil
+    )) ?? []
+
+    return Set(
+        temporaryFiles
+            .map(\.lastPathComponent)
+            .filter { $0.hasPrefix("insforge-multipart-") }
+    )
 }

--- a/Tests/InsForgeStorageTests/StorageChunkedUploadTests.swift
+++ b/Tests/InsForgeStorageTests/StorageChunkedUploadTests.swift
@@ -1,0 +1,225 @@
+import Foundation
+import XCTest
+@testable import InsForgeCore
+@testable import InsForgeStorage
+
+final class StorageChunkedUploadTests: XCTestCase {
+    override func tearDown() {
+        MockURLProtocol.reset()
+        super.tearDown()
+    }
+
+    func testUploadFromFileURLUsesStreamedMultipartBodyForPresignedUploads() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let httpClient = HTTPClient(session: session)
+        let headers = LockIsolated(["Authorization": "Bearer test-token"])
+        let fileApi = StorageFileApi(
+            bucketId: "large-files",
+            url: URL(string: "https://api.example.com/api/storage")!,
+            headersProvider: headers,
+            httpClient: httpClient
+        )
+
+        let sourceData = Data(repeating: 0x41, count: 4096) + Data("chunked-upload".utf8)
+        let sourceFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("chunked-upload-\(UUID().uuidString).txt")
+        try sourceData.write(to: sourceFileURL)
+        defer { try? FileManager.default.removeItem(at: sourceFileURL) }
+
+        MockURLProtocol.requestHandler = { request in
+            guard let url = request.url else {
+                throw InsForgeError.invalidURL
+            }
+
+            switch url.absoluteString {
+            case "https://api.example.com/api/storage/buckets/large-files/upload-strategy":
+                let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                let body = """
+                {
+                    "method": "presigned",
+                    "uploadUrl": "https://uploads.example.com/presigned",
+                    "fields": {
+                        "key": "uploads/large-file.txt",
+                        "policy": "policy-token"
+                    },
+                    "key": "uploads/large-file.txt",
+                    "confirmRequired": true,
+                    "confirmUrl": "/api/storage/buckets/large-files/objects/uploads/large-file.txt/confirm-upload"
+                }
+                """.data(using: .utf8)!
+                return (response, body)
+            case "https://uploads.example.com/presigned":
+                let response = HTTPURLResponse(
+                    url: url,
+                    statusCode: 204,
+                    httpVersion: nil,
+                    headerFields: ["ETag": "\"etag-123\""]
+                )!
+                return (response, Data())
+            default:
+                if url.absoluteString.contains("/confirm-upload") {
+                    let response = HTTPURLResponse(url: url, statusCode: 201, httpVersion: nil, headerFields: nil)!
+                    let body = """
+                    {
+                        "bucket": "large-files",
+                        "key": "uploads/large-file.txt",
+                        "size": \(sourceData.count),
+                        "mimeType": "text/plain",
+                        "uploadedAt": "2025-01-01T00:00:00Z",
+                        "url": "https://cdn.example.com/uploads/large-file.txt"
+                    }
+                    """.data(using: .utf8)!
+                    return (response, body)
+                }
+
+                throw InsForgeError.unknown("Unexpected request: \(url.absoluteString)")
+            }
+        }
+
+        let storedFile = try await fileApi.upload(
+            path: "uploads/large-file.txt",
+            fileURL: sourceFileURL,
+            options: FileOptions(contentType: "text/plain", multipartChunkSize: 17)
+        )
+
+        XCTAssertEqual(storedFile.bucket, "large-files")
+        XCTAssertEqual(storedFile.key, "uploads/large-file.txt")
+
+        let capturedRequests = MockURLProtocol.capturedRequests
+        XCTAssertEqual(capturedRequests.count, 3)
+
+        let strategyRequest = try XCTUnwrap(capturedRequests.first { $0.url.absoluteString.hasSuffix("/upload-strategy") })
+        let strategyJSON = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: strategyRequest.body) as? [String: Any]
+        )
+        XCTAssertEqual(strategyJSON["filename"] as? String, "uploads/large-file.txt")
+        XCTAssertEqual(strategyJSON["contentType"] as? String, "text/plain")
+        XCTAssertEqual(strategyJSON["size"] as? Int, sourceData.count)
+
+        let uploadRequest = try XCTUnwrap(capturedRequests.first { $0.url.absoluteString == "https://uploads.example.com/presigned" })
+        XCTAssertNil(uploadRequest.request.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertTrue(uploadRequest.request.value(forHTTPHeaderField: "Content-Type")?.contains("multipart/form-data; boundary=") == true)
+
+        let uploadBodyString = try XCTUnwrap(String(data: uploadRequest.body, encoding: .utf8))
+        XCTAssertTrue(uploadBodyString.contains("name=\"key\"\r\n\r\nuploads/large-file.txt"))
+        XCTAssertTrue(uploadBodyString.contains("name=\"policy\"\r\n\r\npolicy-token"))
+        XCTAssertTrue(uploadBodyString.contains("filename=\"large-file.txt\""))
+        XCTAssertTrue(uploadBodyString.contains("chunked-upload"))
+
+        let confirmRequest = try XCTUnwrap(capturedRequests.first { $0.url.absoluteString.contains("/confirm-upload") })
+        let confirmJSON = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: confirmRequest.body) as? [String: Any]
+        )
+        XCTAssertEqual(confirmJSON["size"] as? Int, sourceData.count)
+        XCTAssertEqual(confirmJSON["contentType"] as? String, "text/plain")
+        XCTAssertEqual(confirmJSON["etag"] as? String, "etag-123")
+    }
+
+    func testMultipartBodyFileRejectsInvalidChunkSizes() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("invalid-chunk-\(UUID().uuidString).txt")
+        try Data("content".utf8).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        XCTAssertThrowsError(
+            try MultipartFormBodyFile.create(
+                formFields: [:],
+                sourceFileURL: fileURL,
+                fileName: "invalid.txt",
+                mimeType: "text/plain",
+                chunkSize: 0
+            )
+        ) { error in
+            guard case InsForgeError.validationError(let message) = error else {
+                return XCTFail("Expected validation error, got \(error)")
+            }
+
+            XCTAssertEqual(message, "Chunk size must be greater than 0")
+        }
+    }
+}
+
+private struct CapturedRequest {
+    let url: URL
+    let request: URLRequest
+    let body: Data
+}
+
+private final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    private static var storage = LockIsolated<[CapturedRequest]>([])
+
+    static var capturedRequests: [CapturedRequest] {
+        storage.value
+    }
+
+    static func reset() {
+        requestHandler = nil
+        storage.setValue([])
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: InsForgeError.unknown("Missing request handler"))
+            return
+        }
+
+        do {
+            let body = Self.bodyData(from: request)
+            if let url = request.url {
+                Self.storage.withValue { requests in
+                    requests.append(CapturedRequest(url: url, request: request, body: body))
+                }
+            }
+
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    private static func bodyData(from request: URLRequest) -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        while stream.hasBytesAvailable {
+            let read = stream.read(buffer, maxLength: bufferSize)
+            if read > 0 {
+                data.append(buffer, count: read)
+            } else {
+                break
+            }
+        }
+
+        return data
+    }
+}

--- a/Tests/InsForgeStorageTests/StorageChunkedUploadTests.swift
+++ b/Tests/InsForgeStorageTests/StorageChunkedUploadTests.swift
@@ -3,6 +3,10 @@ import XCTest
 @testable import InsForgeCore
 @testable import InsForgeStorage
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 final class StorageChunkedUploadTests: XCTestCase {
     override func tearDown() {
         MockURLProtocol.reset()


### PR DESCRIPTION
## Summary
- stream multipart upload bodies from disk for local-file storage uploads so large files do not require duplicating the request body in memory
- reuse the shared multipart chunk-size default, compute exact multipart `Content-Length`, and clean temporary body files up on failure
- forward upload `ETag` values into `confirmUpload` for both direct and presigned flows so confirmation payloads include the object checksum when the server returns it
- strengthen the storage regression tests to prove the presigned upload is streamed, validate `Content-Length`, reject invalid chunk sizes, and catch temp-file leaks

## Verification
- installed Swift 6.2.4 locally on Windows
- ran a focused `swift test` verification pass against a disposable manifest containing only `InsForgeCore`, `InsForgeStorage`, and the new streamed-upload test target; 3 tests passed
- full package-wide `swift test` on this Windows machine is still blocked by existing repo-level dependency issues outside this patch (`swift-docc-plugin` symlink checkout permissions and missing Windows support for the realtime dependency chain, including `zlib`/`CryptoKit` availability)

Fixes #9.