### PR TITLE
refactor: extract duplicate executeRequest into shared HTTPRequestExe…

### DIFF
--- a/Sources/AI/AIClient.swift
+++ b/Sources/AI/AIClient.swift
@@ -3,11 +3,11 @@ import InsForgeCore
 import Logging
 
 /// AI client for chat and image generation
-public actor AIClient: HTTPRequestExecutable {
+public actor AIClient {
     private let url: URL
     private let headersProvider: LockIsolated<[String: String]>
-    nonisolated let httpClient: HTTPClient
-    nonisolated let tokenRefreshHandler: (any TokenRefreshHandler)?
+    private let httpClient: HTTPClient
+    private let tokenRefreshHandler: (any TokenRefreshHandler)?
     private var logger: Logging.Logger { InsForgeLoggerFactory.shared }
 
     /// Get current headers (dynamically fetched to reflect auth state changes)
@@ -111,7 +111,9 @@ public actor AIClient: HTTPRequestExecutable {
             .post,
             url: endpoint,
             headers: requestHeaders,
-            body: data
+            body: data,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -160,7 +162,9 @@ public actor AIClient: HTTPRequestExecutable {
             .post,
             url: endpoint,
             headers: requestHeaders,
-            body: data
+            body: data,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -220,7 +224,9 @@ public actor AIClient: HTTPRequestExecutable {
             .post,
             url: endpoint,
             headers: requestHeaders,
-            body: data
+            body: data,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -248,7 +254,9 @@ public actor AIClient: HTTPRequestExecutable {
         let response = try await executeRequest(
             .get,
             url: endpoint,
-            headers: headers
+            headers: headers,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response

--- a/Sources/Core/HTTPRequestExecutable.swift
+++ b/Sources/Core/HTTPRequestExecutable.swift
@@ -1,45 +1,33 @@
 import Foundation
 
-// MARK: - HTTPRequestExecutable
+// MARK: - executeRequest
 
-/// A protocol for types that can execute HTTP requests with optional automatic token refresh.
+/// Shared helper for executing HTTP requests with optional automatic token refresh.
 ///
-/// Conforming types must expose an `HTTPClient` and an optional `TokenRefreshHandler`.
-/// The protocol extension provides a default `executeRequest` implementation that
-/// delegates to `executeWithAutoRefresh` when a handler is present, and `execute` otherwise.
-/// A protocol for types that can execute HTTP requests with optional automatic token refresh.
-///
-/// `httpClient` and `tokenRefreshHandler` are intentionally **not** part of the public API —
-/// conforming types expose them as `internal let` (structs) or `nonisolated let` (actors),
-/// so they remain invisible to SDK consumers even though the protocol itself is public.
-public protocol HTTPRequestExecutable {
-    var httpClient: HTTPClient { get }
-    var tokenRefreshHandler: (any TokenRefreshHandler)? { get }
-}
-
-extension HTTPRequestExecutable {
-    /// Executes an HTTP request with optional automatic token refresh on 401 errors.
-    func executeRequest(
-        _ method: HTTPMethod,
-        url: URL,
-        headers: [String: String],
-        body: Data? = nil
-    ) async throws -> HTTPResponse {
-        if let handler = tokenRefreshHandler {
-            return try await httpClient.executeWithAutoRefresh(
-                method,
-                url: url,
-                headers: headers,
-                body: body,
-                refreshHandler: handler
-            )
-        } else {
-            return try await httpClient.execute(
-                method,
-                url: url,
-                headers: headers,
-                body: body
-            )
-        }
+/// This is an internal implementation detail of the InsForge SDK and is not
+/// part of the public API surface.
+public func executeRequest(
+    _ method: HTTPMethod,
+    url: URL,
+    headers: [String: String],
+    body: Data? = nil,
+    httpClient: HTTPClient,
+    tokenRefreshHandler: (any TokenRefreshHandler)?
+) async throws -> HTTPResponse {
+    if let handler = tokenRefreshHandler {
+        return try await httpClient.executeWithAutoRefresh(
+            method,
+            url: url,
+            headers: headers,
+            body: body,
+            refreshHandler: handler
+        )
+    } else {
+        return try await httpClient.execute(
+            method,
+            url: url,
+            headers: headers,
+            body: body
+        )
     }
 }

--- a/Sources/Database/DatabaseClient.swift
+++ b/Sources/Database/DatabaseClient.swift
@@ -148,13 +148,13 @@ public actor DatabaseClient {
 ///
 /// Provides a fluent interface for constructing and executing database queries.
 /// Supports filtering, ordering, pagination, and CRUD operations.
-public struct QueryBuilder: Sendable, HTTPRequestExecutable {
+public struct QueryBuilder: Sendable {
     private let url: URL
     private let headersProvider: LockIsolated<[String: String]>
-    let httpClient: HTTPClient
+    private let httpClient: HTTPClient
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
-    let tokenRefreshHandler: (any TokenRefreshHandler)?
+    private let tokenRefreshHandler: (any TokenRefreshHandler)?
     private var queryItems: [URLQueryItem] = []
     private var preferHeader: String?
     private var countOption: CountOption?
@@ -410,7 +410,9 @@ public struct QueryBuilder: Sendable, HTTPRequestExecutable {
         let response = try await executeRequest(
             method,
             url: requestURL,
-            headers: requestHeaders
+            headers: requestHeaders,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -484,11 +486,13 @@ public struct QueryBuilder: Sendable, HTTPRequestExecutable {
             logger.trace("Request body: \(bodyString)")
         }
 
-        let response = try await builder.executeRequest(
+        let response = try await executeRequest(
             .post,
             url: builder.url,
             headers: requestHeaders,
-            body: data
+            body: data,
+            httpClient: builder.httpClient,
+            tokenRefreshHandler: builder.tokenRefreshHandler
         )
 
         // Log response
@@ -546,7 +550,9 @@ public struct QueryBuilder: Sendable, HTTPRequestExecutable {
             .patch,
             url: requestURL,
             headers: requestHeaders,
-            body: data
+            body: data,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -580,7 +586,9 @@ public struct QueryBuilder: Sendable, HTTPRequestExecutable {
         let response = try await executeRequest(
             .delete,
             url: requestURL,
-            headers: headers
+            headers: headers,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -597,14 +605,14 @@ public struct QueryBuilder: Sendable, HTTPRequestExecutable {
 /// Builder for executing PostgreSQL RPC (Remote Procedure Call) functions.
 ///
 /// Provides a simple interface for calling database functions with optional parameters.
-public struct RPCBuilder: Sendable, HTTPRequestExecutable {
+public struct RPCBuilder: Sendable {
     private let url: URL
     private let headersProvider: LockIsolated<[String: String]>
-    let httpClient: HTTPClient
+    private let httpClient: HTTPClient
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
     private let argsData: Data?
-    let tokenRefreshHandler: (any TokenRefreshHandler)?
+    private let tokenRefreshHandler: (any TokenRefreshHandler)?
 
     /// Logger for debug output
     private var logger: Logging.Logger { InsForgeLoggerFactory.shared }
@@ -657,7 +665,9 @@ public struct RPCBuilder: Sendable, HTTPRequestExecutable {
             .post,
             url: url,
             headers: requestHeaders,
-            body: argsData
+            body: argsData,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -709,7 +719,9 @@ public struct RPCBuilder: Sendable, HTTPRequestExecutable {
             .post,
             url: url,
             headers: requestHeaders,
-            body: argsData
+            body: argsData,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response

--- a/Sources/Storage/StorageClient.swift
+++ b/Sources/Storage/StorageClient.swift
@@ -102,11 +102,11 @@ public struct DownloadStrategy: Codable, Sendable {
 // MARK: - Storage Client
 
 /// Storage client for managing buckets and files
-public actor StorageClient: HTTPRequestExecutable {
+public actor StorageClient {
     private let url: URL
     private let headersProvider: LockIsolated<[String: String]>
-    nonisolated let httpClient: HTTPClient
-    nonisolated let tokenRefreshHandler: (any TokenRefreshHandler)?
+    private let httpClient: HTTPClient
+    private let tokenRefreshHandler: (any TokenRefreshHandler)?
     private var logger: Logging.Logger { InsForgeLoggerFactory.shared }
 
     /// Get current headers (dynamically fetched to reflect auth state changes)
@@ -159,7 +159,9 @@ public actor StorageClient: HTTPRequestExecutable {
         let response = try await executeRequest(
             .get,
             url: endpoint,
-            headers: headers
+            headers: headers,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -187,7 +189,9 @@ public actor StorageClient: HTTPRequestExecutable {
         let response = try await executeRequest(
             .get,
             url: endpoint,
-            headers: headers
+            headers: headers,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -228,7 +232,9 @@ public actor StorageClient: HTTPRequestExecutable {
             .post,
             url: endpoint,
             headers: requestHeaders,
-            body: data
+            body: data,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -266,7 +272,9 @@ public actor StorageClient: HTTPRequestExecutable {
             .patch,
             url: endpoint,
             headers: requestHeaders,
-            body: data
+            body: data,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -291,7 +299,9 @@ public actor StorageClient: HTTPRequestExecutable {
         let response = try await executeRequest(
             .delete,
             url: endpoint,
-            headers: headers
+            headers: headers,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -308,12 +318,12 @@ public actor StorageClient: HTTPRequestExecutable {
 // MARK: - Storage File API
 
 /// Storage file operations for a specific bucket
-public struct StorageFileApi: Sendable, HTTPRequestExecutable {
+public struct StorageFileApi: Sendable {
     private let bucketId: String
     private let url: URL
     private let headersProvider: LockIsolated<[String: String]>
-    let httpClient: HTTPClient
-    let tokenRefreshHandler: (any TokenRefreshHandler)?
+    private let httpClient: HTTPClient
+    private let tokenRefreshHandler: (any TokenRefreshHandler)?
     private var logger: Logging.Logger { InsForgeLoggerFactory.shared }
 
     /// Get current headers (dynamically fetched to reflect auth state changes)
@@ -584,7 +594,9 @@ public struct StorageFileApi: Sendable, HTTPRequestExecutable {
         let response = try await executeRequest(
             .get,
             url: requestURL,
-            headers: headers
+            headers: headers,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -631,7 +643,9 @@ public struct StorageFileApi: Sendable, HTTPRequestExecutable {
         let response = try await executeRequest(
             .delete,
             url: endpoint,
-            headers: headers
+            headers: headers,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -697,7 +711,9 @@ public struct StorageFileApi: Sendable, HTTPRequestExecutable {
             .post,
             url: endpoint,
             headers: requestHeaders,
-            body: data
+            body: data,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -757,7 +773,9 @@ public struct StorageFileApi: Sendable, HTTPRequestExecutable {
             .post,
             url: endpoint,
             headers: requestHeaders,
-            body: data
+            body: data,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response
@@ -805,7 +823,9 @@ public struct StorageFileApi: Sendable, HTTPRequestExecutable {
             .post,
             url: endpoint,
             headers: requestHeaders,
-            body: data
+            body: data,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         // Log response


### PR DESCRIPTION
…cutable protocol

Removed identical executeRequest implementations from QueryBuilder, RPCBuilder, StorageClient, StorageFileApi, and AIClient. Extracted into a protocol extension in Core/HTTPRequestExecutable.swift so all 5 types share a single implementation.