### PR TITLE
feat: support custom OAuth providers in signInWithOAuthView

### DIFF
--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -476,9 +476,10 @@ public actor AuthClient {
         try await storage.savePKCEVerifier(pkce.codeVerifier)
         logger.trace("Saved PKCE verifier to storage")
 
-        let sanitizedKey = providerKey
-            .addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? providerKey
-        let endpoint = url.appendingPathComponent("oauth/custom/\(sanitizedKey)")
+        let endpoint = url
+            .appendingPathComponent("oauth")
+            .appendingPathComponent("custom")
+            .appendingPathComponent(providerKey)
 
         var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false)!
         components.queryItems = [


### PR DESCRIPTION
## Summary

- Adds `.custom(String)` case to `OAuthProvider` enum for custom OAuth providers configured in the InsForge dashboard
- Auto-routes requests to the correct endpoint:
  - Built-in → `GET /api/auth/oauth/{provider}`
  - Custom → `GET /api/auth/oauth/custom/{key}`
- PKCE flow, code exchange, and session management work identically for both

## Context

Follows the merge of [InsForge/InsForge#859](https://github.com/InsForge/InsForge/pull/859) (backend custom OAuth) and the JS SDK PR in [InsForge/insforge-sdk-js#53](https://github.com/InsForge/insforge-sdk-js/pull/54). As suggested by the maintainer.

Relates to [InsForge/InsForge#845](https://github.com/InsForge/InsForge/issues/845).

## Usage

```swift
// Built-in provider (unchanged)
try await client.auth.signInWithOAuthView(provider: .google, redirectTo: "myapp://auth")

// Custom OAuth provider (new)
try await client.auth.signInWithOAuthView(provider: .custom("auth0-acme"), redirectTo: "myapp://auth")
```
### Test plan

swift build (passes)

All 33 auth tests pass (`swift test --filter InsForgeAuthTests`)

New `testOAuthProviderCustom` verifies correct routing and properties

Same backend endpoint verified end-to-end in JS SDK PR

<img width="534" height="300" alt="image" src="https://github.com/user-attachments/assets/4ff04852-4866-4bea-99d7-5f5dd92236a9" />
