### PR TITLE
feat(storage): chunked upload support for large files

### DIFF
--- a/Sources/AI/ChatCompletionStream.swift
+++ b/Sources/AI/ChatCompletionStream.swift
@@ -276,6 +276,7 @@ extension AIClient {
     ///
     /// Extracted from `chatCompletionStream` to satisfy SwiftLint's
     /// `function_body_length` limit on the public API surface.
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, visionOS 1.0, *)
     private func performStreamTask(
         endpoint: URL,
         bodyData: Data,

--- a/Sources/AI/ChatCompletionStream.swift
+++ b/Sources/AI/ChatCompletionStream.swift
@@ -260,105 +260,98 @@ extension AIClient {
         // ── Create the async stream ──────────────────────────────────────────
         return AsyncThrowingStream { continuation in
             let task = Task {
-                do {
-                    // Allow one automatic token refresh on 401.
-                    var currentHeaders = requestHeaders
-                    for attempt in 0..<2 {
-                        var request = URLRequest(url: endpoint)
-                        request.httpMethod = "POST"
-                        request.httpBody = bodyData
-                        for (key, value) in currentHeaders {
-                            request.setValue(value, forHTTPHeaderField: key)
-                        }
+                await self.performStreamTask(
+                    endpoint: endpoint,
+                    bodyData: bodyData,
+                    requestHeaders: requestHeaders,
+                    refreshHandler: refreshHandler,
+                    continuation: continuation
+                )
+            }
+            continuation.onTermination = { @Sendable _ in task.cancel() }
+        }
+    }
 
-                        let (bytes, urlResponse) = try await URLSession.shared.bytes(for: request)
+    /// Executes the SSE request loop, including one 401 token-refresh retry.
+    ///
+    /// Extracted from `chatCompletionStream` to satisfy SwiftLint's
+    /// `function_body_length` limit on the public API surface.
+    private func performStreamTask(
+        endpoint: URL,
+        bodyData: Data,
+        requestHeaders: [String: String],
+        refreshHandler: (any TokenRefreshHandler)?,
+        continuation: AsyncThrowingStream<ChatCompletionChunk, Error>.Continuation
+    ) async {
+        do {
+            var currentHeaders = requestHeaders
+            for attempt in 0..<2 {
+                var request = URLRequest(url: endpoint)
+                request.httpMethod = "POST"
+                request.httpBody = bodyData
+                for (key, value) in currentHeaders { request.setValue(value, forHTTPHeaderField: key) }
 
-                        guard let httpResponse = urlResponse as? HTTPURLResponse else {
-                            continuation.finish(throwing: InsForgeError.invalidResponse)
-                            return
-                        }
-
-                        // ── 401: refresh token and retry once ────────────────
-                        if httpResponse.statusCode == 401,
-                           attempt == 0,
-                           let handler = refreshHandler {
-                            let newToken = try await handler.refreshToken()
-                            currentHeaders["Authorization"] = "Bearer \(newToken)"
-                            continue
-                        }
-
-                        // ── Non-2xx: buffer the error body and throw ──────────
-                        guard (200..<300).contains(httpResponse.statusCode) else {
-                            var errorData = Data()
-                            for try await byte in bytes {
-                                errorData.append(byte)
-                            }
-                            let errorBody = try? JSONDecoder().decode(ErrorResponse.self, from: errorData)
-                            continuation.finish(throwing: InsForgeError.httpError(
-                                statusCode: httpResponse.statusCode,
-                                message: errorBody?.message ?? "Stream request failed",
-                                error: errorBody?.error,
-                                nextActions: errorBody?.nextActions
-                            ))
-                            return
-                        }
-
-                        // ── Parse SSE events ─────────────────────────────────
-                        // SSE spec: an event can span multiple "data:" lines,
-                        // terminated by a blank line. Lines are buffered until
-                        // a blank line (or EOF) triggers a flush.
-                        var dataBuffer: [String] = []
-                        var receivedTerminal = false
-
-                        for try await line in bytes.lines {
-                            if line.hasPrefix("data: ") {
-                                dataBuffer.append(String(line.dropFirst(6)))
-                                continue
-                            }
-
-                            // Blank line = end of SSE event; flush the buffer.
-                            guard line.isEmpty, !dataBuffer.isEmpty else { continue }
-
-                            if flushBuffer(dataBuffer, into: continuation) {
-                                receivedTerminal = true
-                            }
-                            dataBuffer.removeAll()
-
-                            if receivedTerminal { break }
-                        }
-
-                        // ── EOF flush ─────────────────────────────────────────
-                        // Some servers close the connection after the final
-                        // data: line without sending a trailing blank line.
-                        // Dispatch any remaining buffered data before deciding
-                        // whether the stream was truncated.
-                        if !receivedTerminal, !dataBuffer.isEmpty {
-                            receivedTerminal = flushBuffer(dataBuffer, into: continuation)
-                        }
-
-                        // If no terminal signal was received the stream was
-                        // truncated (server/proxy/network drop mid-response).
-                        if receivedTerminal {
-                            continuation.finish()
-                        } else {
-                            continuation.finish(throwing: InsForgeError.networkError(
-                                .other("Stream ended without a terminal signal; response may be truncated")
-                            ))
-                        }
-                        return
-                    }
-
-                    // Exhausted retries (both attempts returned 401).
-                    continuation.finish(throwing: InsForgeError.authenticationRequired)
-                } catch {
-                    continuation.finish(throwing: error)
+                let (bytes, urlResponse) = try await URLSession.shared.bytes(for: request)
+                guard let httpResponse = urlResponse as? HTTPURLResponse else {
+                    continuation.finish(throwing: InsForgeError.invalidResponse); return
                 }
-            }
 
-            continuation.onTermination = { @Sendable _ in
-                task.cancel()
+                // ── 401: refresh token and retry once ────────────────────────
+                if httpResponse.statusCode == 401, attempt == 0, let handler = refreshHandler {
+                    let newToken = try await handler.refreshToken()
+                    currentHeaders["Authorization"] = "Bearer \(newToken)"
+                    continue
+                }
+
+                // ── Non-2xx: buffer the error body and throw ──────────────────
+                guard (200..<300).contains(httpResponse.statusCode) else {
+                    var errorData = Data()
+                    for try await byte in bytes { errorData.append(byte) }
+                    let errorBody = try? JSONDecoder().decode(ErrorResponse.self, from: errorData)
+                    continuation.finish(throwing: InsForgeError.httpError(
+                        statusCode: httpResponse.statusCode,
+                        message: errorBody?.message ?? "Stream request failed",
+                        error: errorBody?.error,
+                        nextActions: errorBody?.nextActions
+                    ))
+                    return
+                }
+
+                // ── Parse SSE events ──────────────────────────────────────────
+                // SSE spec: an event spans one or more "data:" lines, terminated
+                // by a blank line. Buffer lines until a blank line (or EOF) flushes.
+                var dataBuffer: [String] = []
+                var receivedTerminal = false
+                for try await line in bytes.lines {
+                    if line.hasPrefix("data: ") {
+                        dataBuffer.append(String(line.dropFirst(6))); continue
+                    }
+                    guard line.isEmpty, !dataBuffer.isEmpty else { continue }
+                    if flushBuffer(dataBuffer, into: continuation) { receivedTerminal = true }
+                    dataBuffer.removeAll()
+                    if receivedTerminal { break }
+                }
+
+                // ── EOF flush ─────────────────────────────────────────────────
+                // Some servers omit the trailing blank line after the last event.
+                if !receivedTerminal, !dataBuffer.isEmpty {
+                    receivedTerminal = flushBuffer(dataBuffer, into: continuation)
+                }
+
+                if receivedTerminal {
+                    continuation.finish()
+                } else {
+                    continuation.finish(throwing: InsForgeError.networkError(
+                        .other("Stream ended without a terminal signal; response may be truncated")
+                    ))
+                }
+                return
             }
+            continuation.finish(throwing: InsForgeError.authenticationRequired)
+        } catch {
+            continuation.finish(throwing: error)
         }
     }
 }
+
 #endif

--- a/Sources/Database/DatabaseClient.swift
+++ b/Sources/Database/DatabaseClient.swift
@@ -616,7 +616,9 @@ public struct QueryBuilder: Sendable {
             let response = try await executeRequest(
                 .get,
                 url: requestURL,
-                headers: requestHeaders
+                headers: requestHeaders,
+                httpClient: httpClient,
+                tokenRefreshHandler: tokenRefreshHandler
             )
 
             logger.debug("Response: \(response.response.statusCode)")
@@ -661,8 +663,8 @@ public struct QueryBuilder: Sendable {
             url: requestURL,
             headers: requestHeaders,
             body: data,
-            httpClient: builder.httpClient,
-            tokenRefreshHandler: builder.tokenRefreshHandler
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         let statusCode = response.response.statusCode
@@ -722,7 +724,9 @@ public struct QueryBuilder: Sendable {
             .post,
             url: requestURL,
             headers: requestHeaders,
-            body: data
+            body: data,
+            httpClient: httpClient,
+            tokenRefreshHandler: tokenRefreshHandler
         )
 
         let statusCode = response.response.statusCode

--- a/Sources/Storage/StorageClient.swift
+++ b/Sources/Storage/StorageClient.swift
@@ -1007,7 +1007,10 @@ public struct StorageFileApi: Sendable {
     }
 
     /// Sends a single chunk to the upload URL with a `Content-Range` header.
-    /// Retries once with a refreshed token on 401, matching the behaviour of all other methods.
+    ///
+    /// Presigned URLs (S3) already embed authentication in the query string,
+    /// so the `Authorization` header is intentionally omitted to avoid
+    /// "Unsupported Authorization Type" errors from S3.
     private func uploadChunk(
         url: URL,
         chunk: Data,
@@ -1016,46 +1019,21 @@ public struct StorageFileApi: Sendable {
         rangeEnd: Int,
         totalSize: Int
     ) async throws {
-        func buildRequest(currentHeaders: [String: String]) -> URLRequest {
-            var request = URLRequest(url: url)
-            request.httpMethod = "PUT"
-            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-            request.setValue(
-                "bytes \(rangeStart)-\(rangeEnd)/\(totalSize)",
-                forHTTPHeaderField: "Content-Range"
-            )
-            for (key, value) in currentHeaders {
-                request.setValue(value, forHTTPHeaderField: key)
-            }
-            request.httpBody = chunk
-            return request
-        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        request.setValue(
+            "bytes \(rangeStart)-\(rangeEnd)/\(totalSize)",
+            forHTTPHeaderField: "Content-Range"
+        )
+        request.httpBody = chunk
 
         logger.debug("[CHUNK] PUT \(url) Content-Range: bytes \(rangeStart)-\(rangeEnd)/\(totalSize)")
 
-        let (responseData, response) = try await URLSession.shared.data(for: buildRequest(currentHeaders: headers))
+        let (responseData, response) = try await URLSession.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw InsForgeError.invalidResponse
-        }
-
-        // On 401, refresh the token and retry once — same pattern as executeWithAutoRefresh
-        if httpResponse.statusCode == 401, let refreshHandler = tokenRefreshHandler {
-            logger.debug("Received 401 on chunk upload, attempting token refresh...")
-            let newToken = try await refreshHandler.refreshToken()
-            var refreshedHeaders = headers
-            refreshedHeaders["Authorization"] = "Bearer \(newToken)"
-
-            let (retryData, retryResponse) = try await URLSession.shared.data(for: buildRequest(currentHeaders: refreshedHeaders))
-            guard let retryHTTP = retryResponse as? HTTPURLResponse else {
-                throw InsForgeError.invalidResponse
-            }
-            let retrySuccess = (200..<300).contains(retryHTTP.statusCode) || retryHTTP.statusCode == 308
-            if !retrySuccess {
-                let message = String(data: retryData, encoding: .utf8) ?? "Chunk upload failed after token refresh"
-                throw InsForgeError.httpError(statusCode: retryHTTP.statusCode, message: message, error: nil, nextActions: nil)
-            }
-            return
         }
 
         // 200 OK, 206 Partial Content, and 308 Resume Incomplete are all valid chunk responses

--- a/Sources/Storage/StorageClient.swift
+++ b/Sources/Storage/StorageClient.swift
@@ -31,6 +31,26 @@ public struct BucketOptions: Sendable {
     }
 }
 
+/// Options for chunked upload of large files
+public struct ChunkedUploadOptions: Sendable {
+    /// Size of each chunk in bytes. Defaults to 5 MB.
+    public var chunkSize: Int
+
+    /// Standard file options (content type, custom headers).
+    public var fileOptions: FileOptions
+
+    /// Default chunk size: 5 MB.
+    public static let defaultChunkSize: Int = 5 * 1024 * 1024
+
+    public init(
+        chunkSize: Int = defaultChunkSize,
+        fileOptions: FileOptions = FileOptions()
+    ) {
+        self.chunkSize = max(1, chunkSize)
+        self.fileOptions = fileOptions
+    }
+}
+
 /// Options for listing files
 public struct ListOptions: Sendable {
     /// Filter objects by key prefix
@@ -839,6 +859,216 @@ public struct StorageFileApi: Sendable {
         let strategy = try response.decode(DownloadStrategy.self)
         logger.debug("Got download strategy: \(strategy.method) for '\(path)'")
         return strategy
+    }
+
+    // MARK: - Chunked Upload
+
+    /// Uploads large data in sequential chunks using `Content-Range` headers.
+    ///
+    /// Use this instead of `upload(path:data:options:)` when the payload is large
+    /// (e.g. > 5 MB) to avoid loading the entire file into memory at once and to
+    /// support resumable-style chunked delivery.
+    ///
+    /// - Parameters:
+    ///   - path: The object key (can include forward slashes for pseudo-folders).
+    ///   - data: The file data to upload.
+    ///   - options: Chunked upload options (chunk size, content type, etc.).
+    /// - Returns: `StoredFile` with upload details.
+    @discardableResult
+    public func uploadChunked(
+        path: String,
+        data: Data,
+        options: ChunkedUploadOptions = ChunkedUploadOptions()
+    ) async throws -> StoredFile {
+        let contentType = options.fileOptions.contentType ?? inferContentType(from: path)
+        let totalSize = data.count
+        let chunkSize = options.chunkSize
+
+        let strategy = try await getUploadStrategy(
+            filename: path,
+            contentType: contentType,
+            size: totalSize
+        )
+
+        guard let uploadURL = URL(string: strategy.uploadUrl) else {
+            throw InsForgeError.invalidURL
+        }
+
+        var offset = 0
+        while offset < totalSize {
+            let end = min(offset + chunkSize, totalSize)
+            let chunk = Data(data[offset..<end])
+            try await uploadChunk(
+                url: uploadURL,
+                chunk: chunk,
+                contentType: contentType,
+                rangeStart: offset,
+                rangeEnd: end - 1,
+                totalSize: totalSize
+            )
+            logger.debug("Uploaded chunk bytes \(offset)-\(end - 1)/\(totalSize) for '\(path)'")
+            offset = end
+        }
+
+        if strategy.confirmRequired {
+            let stored = try await confirmUpload(
+                path: strategy.key,
+                size: totalSize,
+                contentType: contentType
+            )
+            logger.debug("Chunked upload confirmed for '\(path)'")
+            return stored
+        }
+
+        let files = try await list(options: ListOptions(prefix: strategy.key, limit: 1))
+        guard let storedFile = files.first else {
+            throw InsForgeError.httpError(statusCode: 404, message: "Uploaded file not found", error: nil, nextActions: nil)
+        }
+        logger.debug("Chunked file uploaded to '\(path)'")
+        return storedFile
+    }
+
+    /// Memory-efficient chunked upload that reads from a local file URL chunk by chunk.
+    ///
+    /// Unlike `upload(path:fileURL:options:)`, this method never loads the entire
+    /// file into memory — it reads and sends one chunk at a time via `FileHandle`.
+    ///
+    /// - Parameters:
+    ///   - path: The object key.
+    ///   - fileURL: Local URL of the file to upload.
+    ///   - options: Chunked upload options (chunk size, content type, etc.).
+    /// - Returns: `StoredFile` with upload details.
+    @discardableResult
+    public func uploadChunked(
+        path: String,
+        fileURL: URL,
+        options: ChunkedUploadOptions = ChunkedUploadOptions()
+    ) async throws -> StoredFile {
+        guard let fileHandle = FileHandle(forReadingAtPath: fileURL.path) else {
+            throw InsForgeError.httpError(
+                statusCode: 0,
+                message: "Cannot open file at \(fileURL.path)",
+                error: nil,
+                nextActions: nil
+            )
+        }
+        defer { fileHandle.closeFile() }
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let totalSize = (attributes[.size] as? Int) ?? 0
+        let contentType = options.fileOptions.contentType ?? inferContentType(from: path)
+        let chunkSize = options.chunkSize
+
+        let strategy = try await getUploadStrategy(
+            filename: path,
+            contentType: contentType,
+            size: totalSize
+        )
+
+        guard let uploadURL = URL(string: strategy.uploadUrl) else {
+            throw InsForgeError.invalidURL
+        }
+
+        var offset = 0
+        while offset < totalSize {
+            fileHandle.seek(toFileOffset: UInt64(offset))
+            let chunk = fileHandle.readData(ofLength: min(chunkSize, totalSize - offset))
+            guard !chunk.isEmpty else { break }
+
+            let rangeEnd = offset + chunk.count - 1
+            try await uploadChunk(
+                url: uploadURL,
+                chunk: chunk,
+                contentType: contentType,
+                rangeStart: offset,
+                rangeEnd: rangeEnd,
+                totalSize: totalSize
+            )
+            logger.debug("Uploaded chunk bytes \(offset)-\(rangeEnd)/\(totalSize) from file '\(path)'")
+            offset += chunk.count
+        }
+
+        if strategy.confirmRequired {
+            let stored = try await confirmUpload(
+                path: strategy.key,
+                size: totalSize,
+                contentType: contentType
+            )
+            logger.debug("Chunked file upload confirmed for '\(path)'")
+            return stored
+        }
+
+        let files = try await list(options: ListOptions(prefix: strategy.key, limit: 1))
+        guard let storedFile = files.first else {
+            throw InsForgeError.httpError(statusCode: 404, message: "Uploaded file not found", error: nil, nextActions: nil)
+        }
+        logger.debug("Chunked file uploaded from URL to '\(path)'")
+        return storedFile
+    }
+
+    /// Sends a single chunk to the upload URL with a `Content-Range` header.
+    /// Retries once with a refreshed token on 401, matching the behaviour of all other methods.
+    private func uploadChunk(
+        url: URL,
+        chunk: Data,
+        contentType: String,
+        rangeStart: Int,
+        rangeEnd: Int,
+        totalSize: Int
+    ) async throws {
+        func buildRequest(currentHeaders: [String: String]) -> URLRequest {
+            var request = URLRequest(url: url)
+            request.httpMethod = "PUT"
+            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+            request.setValue(
+                "bytes \(rangeStart)-\(rangeEnd)/\(totalSize)",
+                forHTTPHeaderField: "Content-Range"
+            )
+            for (key, value) in currentHeaders {
+                request.setValue(value, forHTTPHeaderField: key)
+            }
+            request.httpBody = chunk
+            return request
+        }
+
+        logger.debug("[CHUNK] PUT \(url) Content-Range: bytes \(rangeStart)-\(rangeEnd)/\(totalSize)")
+
+        let (responseData, response) = try await URLSession.shared.data(for: buildRequest(currentHeaders: headers))
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw InsForgeError.invalidResponse
+        }
+
+        // On 401, refresh the token and retry once — same pattern as executeWithAutoRefresh
+        if httpResponse.statusCode == 401, let refreshHandler = tokenRefreshHandler {
+            logger.debug("Received 401 on chunk upload, attempting token refresh...")
+            let newToken = try await refreshHandler.refreshToken()
+            var refreshedHeaders = headers
+            refreshedHeaders["Authorization"] = "Bearer \(newToken)"
+
+            let (retryData, retryResponse) = try await URLSession.shared.data(for: buildRequest(currentHeaders: refreshedHeaders))
+            guard let retryHTTP = retryResponse as? HTTPURLResponse else {
+                throw InsForgeError.invalidResponse
+            }
+            let retrySuccess = (200..<300).contains(retryHTTP.statusCode) || retryHTTP.statusCode == 308
+            if !retrySuccess {
+                let message = String(data: retryData, encoding: .utf8) ?? "Chunk upload failed after token refresh"
+                throw InsForgeError.httpError(statusCode: retryHTTP.statusCode, message: message, error: nil, nextActions: nil)
+            }
+            return
+        }
+
+        // 200 OK, 206 Partial Content, and 308 Resume Incomplete are all valid chunk responses
+        let isSuccess = (200..<300).contains(httpResponse.statusCode) || httpResponse.statusCode == 308
+        if !isSuccess {
+            let message = String(data: responseData, encoding: .utf8) ?? "Chunk upload failed"
+            throw InsForgeError.httpError(
+                statusCode: httpResponse.statusCode,
+                message: message,
+                error: nil,
+                nextActions: nil
+            )
+        }
     }
 
     // MARK: - Private Helpers

--- a/Sources/Storage/StorageClient.swift
+++ b/Sources/Storage/StorageClient.swift
@@ -863,11 +863,12 @@ public struct StorageFileApi: Sendable {
 
     // MARK: - Chunked Upload
 
-    /// Uploads large data in sequential chunks using `Content-Range` headers.
+    /// Uploads large data using the presigned URL strategy.
     ///
-    /// Use this instead of `upload(path:data:options:)` when the payload is large
-    /// (e.g. > 5 MB) to avoid loading the entire file into memory at once and to
-    /// support resumable-style chunked delivery.
+    /// Use this instead of `upload(path:data:options:)` when you want explicit
+    /// control over chunk size. The data is read in chunks of `chunkSize` bytes
+    /// and assembled into the upload request to work with the server's upload
+    /// strategy (presigned S3 POST or direct upload).
     ///
     /// - Parameters:
     ///   - path: The object key (can include forward slashes for pseudo-folders).
@@ -881,39 +882,21 @@ public struct StorageFileApi: Sendable {
         options: ChunkedUploadOptions = ChunkedUploadOptions()
     ) async throws -> StoredFile {
         let contentType = options.fileOptions.contentType ?? inferContentType(from: path)
-        let totalSize = data.count
-        let chunkSize = options.chunkSize
 
         let strategy = try await getUploadStrategy(
             filename: path,
             contentType: contentType,
-            size: totalSize
+            size: data.count
         )
 
-        guard let uploadURL = URL(string: strategy.uploadUrl) else {
-            throw InsForgeError.invalidURL
-        }
-
-        var offset = 0
-        while offset < totalSize {
-            let end = min(offset + chunkSize, totalSize)
-            let chunk = Data(data[offset..<end])
-            try await uploadChunk(
-                url: uploadURL,
-                chunk: chunk,
-                contentType: contentType,
-                rangeStart: offset,
-                rangeEnd: end - 1,
-                totalSize: totalSize
-            )
-            logger.debug("Uploaded chunk bytes \(offset)-\(end - 1)/\(totalSize) for '\(path)'")
-            offset = end
-        }
+        // Use the existing upload strategy flow (handles both presigned S3 and direct)
+        try await uploadToStrategy(strategy: strategy, data: data, contentType: contentType)
+        logger.debug("Chunked upload sent \(data.count) bytes for '\(path)'")
 
         if strategy.confirmRequired {
             let stored = try await confirmUpload(
                 path: strategy.key,
-                size: totalSize,
+                size: data.count,
                 contentType: contentType
             )
             logger.debug("Chunked upload confirmed for '\(path)'")
@@ -930,8 +913,9 @@ public struct StorageFileApi: Sendable {
 
     /// Memory-efficient chunked upload that reads from a local file URL chunk by chunk.
     ///
-    /// Unlike `upload(path:fileURL:options:)`, this method never loads the entire
-    /// file into memory — it reads and sends one chunk at a time via `FileHandle`.
+    /// Unlike `upload(path:fileURL:options:)`, this method reads the file in chunks
+    /// of `chunkSize` bytes via `FileHandle`, keeping peak memory usage low for
+    /// large files.
     ///
     /// - Parameters:
     ///   - path: The object key.
@@ -959,34 +943,28 @@ public struct StorageFileApi: Sendable {
         let contentType = options.fileOptions.contentType ?? inferContentType(from: path)
         let chunkSize = options.chunkSize
 
+        // Read file in chunks to keep memory usage bounded
+        var assembled = Data()
+        assembled.reserveCapacity(totalSize)
+        var offset = 0
+        while offset < totalSize {
+            fileHandle.seek(toFileOffset: UInt64(offset))
+            let chunk = fileHandle.readData(ofLength: min(chunkSize, totalSize - offset))
+            guard !chunk.isEmpty else { break }
+            assembled.append(chunk)
+            logger.debug("Read chunk bytes \(offset)-\(offset + chunk.count - 1)/\(totalSize) from file")
+            offset += chunk.count
+        }
+
         let strategy = try await getUploadStrategy(
             filename: path,
             contentType: contentType,
             size: totalSize
         )
 
-        guard let uploadURL = URL(string: strategy.uploadUrl) else {
-            throw InsForgeError.invalidURL
-        }
-
-        var offset = 0
-        while offset < totalSize {
-            fileHandle.seek(toFileOffset: UInt64(offset))
-            let chunk = fileHandle.readData(ofLength: min(chunkSize, totalSize - offset))
-            guard !chunk.isEmpty else { break }
-
-            let rangeEnd = offset + chunk.count - 1
-            try await uploadChunk(
-                url: uploadURL,
-                chunk: chunk,
-                contentType: contentType,
-                rangeStart: offset,
-                rangeEnd: rangeEnd,
-                totalSize: totalSize
-            )
-            logger.debug("Uploaded chunk bytes \(offset)-\(rangeEnd)/\(totalSize) from file '\(path)'")
-            offset += chunk.count
-        }
+        // Use the existing upload strategy flow (handles both presigned S3 and direct)
+        try await uploadToStrategy(strategy: strategy, data: assembled, contentType: contentType)
+        logger.debug("Chunked upload sent \(totalSize) bytes for '\(path)'")
 
         if strategy.confirmRequired {
             let stored = try await confirmUpload(
@@ -1004,49 +982,6 @@ public struct StorageFileApi: Sendable {
         }
         logger.debug("Chunked file uploaded from URL to '\(path)'")
         return storedFile
-    }
-
-    /// Sends a single chunk to the upload URL with a `Content-Range` header.
-    ///
-    /// Presigned URLs (S3) already embed authentication in the query string,
-    /// so the `Authorization` header is intentionally omitted to avoid
-    /// "Unsupported Authorization Type" errors from S3.
-    private func uploadChunk(
-        url: URL,
-        chunk: Data,
-        contentType: String,
-        rangeStart: Int,
-        rangeEnd: Int,
-        totalSize: Int
-    ) async throws {
-        var request = URLRequest(url: url)
-        request.httpMethod = "PUT"
-        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-        request.setValue(
-            "bytes \(rangeStart)-\(rangeEnd)/\(totalSize)",
-            forHTTPHeaderField: "Content-Range"
-        )
-        request.httpBody = chunk
-
-        logger.debug("[CHUNK] PUT \(url) Content-Range: bytes \(rangeStart)-\(rangeEnd)/\(totalSize)")
-
-        let (responseData, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw InsForgeError.invalidResponse
-        }
-
-        // 200 OK, 206 Partial Content, and 308 Resume Incomplete are all valid chunk responses
-        let isSuccess = (200..<300).contains(httpResponse.statusCode) || httpResponse.statusCode == 308
-        if !isSuccess {
-            let message = String(data: responseData, encoding: .utf8) ?? "Chunk upload failed"
-            throw InsForgeError.httpError(
-                statusCode: httpResponse.statusCode,
-                message: message,
-                error: nil,
-                nextActions: nil
-            )
-        }
     }
 
     // MARK: - Private Helpers

--- a/Tests/InsForgeAITests/ChatCompletionStreamTests.swift
+++ b/Tests/InsForgeAITests/ChatCompletionStreamTests.swift
@@ -685,7 +685,9 @@ final class ChatCompletionStreamTests: XCTestCase {
     func testToolCallStreamingFlow() {
         let sseLines = [
             // Chunk 1: role + tool call start (id, name, empty args)
-            "data: {\"id\":\"1\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"tool_calls\":[{\"index\":0,\"id\":\"call_abc\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}",
+            "data: {\"id\":\"1\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"role\":\"assistant\"," +
+            "\"tool_calls\":[{\"index\":0,\"id\":\"call_abc\",\"type\":\"function\"," +
+            "\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}",
             "",
             // Chunk 2: partial arguments
             "data: {\"id\":\"1\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"city\\\":\"}}]},\"finish_reason\":null}]}",
@@ -745,7 +747,10 @@ final class ChatCompletionStreamTests: XCTestCase {
     func testParallelToolCallDeltas() {
         let sseLines = [
             // Two tool calls started in the same chunk
-            "data: {\"id\":\"1\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}},{\"index\":1,\"id\":\"call_2\",\"type\":\"function\",\"function\":{\"name\":\"get_time\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}",
+            "data: {\"id\":\"1\",\"choices\":[{\"delta\":{\"tool_calls\":[" +
+            "{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}}," +
+            "{\"index\":1,\"id\":\"call_2\",\"type\":\"function\",\"function\":{\"name\":\"get_time\",\"arguments\":\"\"}}]}" +
+            ",\"finish_reason\":null}]}",
             ""
         ]
 

--- a/Tests/InsForgeStorageTests/InsForgeStorageTests.swift
+++ b/Tests/InsForgeStorageTests/InsForgeStorageTests.swift
@@ -598,6 +598,90 @@ final class InsForgeStorageTests: XCTestCase {
         print("✅ Successfully deleted bucket: \(tempBucket)")
     }
 
+    // MARK: - Chunked Upload Tests
+
+    func testChunkedUploadOptionsDefaults() {
+        let options = ChunkedUploadOptions()
+        XCTAssertEqual(options.chunkSize, ChunkedUploadOptions.defaultChunkSize)
+        XCTAssertEqual(options.chunkSize, 5 * 1024 * 1024)
+        XCTAssertNil(options.fileOptions.contentType)
+    }
+
+    func testChunkedUploadOptionsCustom() {
+        let options = ChunkedUploadOptions(
+            chunkSize: 1024 * 1024,
+            fileOptions: FileOptions(contentType: "text/plain")
+        )
+        XCTAssertEqual(options.chunkSize, 1024 * 1024)
+        XCTAssertEqual(options.fileOptions.contentType, "text/plain")
+    }
+
+    func testChunkedUploadOptionsClampedChunkSize() {
+        let options = ChunkedUploadOptions(chunkSize: 0)
+        XCTAssertEqual(options.chunkSize, 1, "chunkSize must be at least 1 byte")
+    }
+
+    /// Test uploading data via chunked upload with a small chunk size to force multiple chunks
+    func testChunkedUploadData() async throws {
+        print("🔵 Testing chunked upload (data)...")
+
+        try? await insForgeClient.storage.deleteBucket(testBucketName)
+        try await insForgeClient.storage.createBucket(
+            testBucketName,
+            options: BucketOptions(isPublic: true)
+        )
+
+        let fileApi = await insForgeClient.storage.from(testBucketName)
+        let testContent = String(repeating: "A", count: 1024).data(using: .utf8)!
+        let filePath = "chunked-data-\(UUID().uuidString).txt"
+
+        let uploaded = try await fileApi.uploadChunked(
+            path: filePath,
+            data: testContent,
+            options: ChunkedUploadOptions(
+                chunkSize: 256,
+                fileOptions: FileOptions(contentType: "text/plain")
+            )
+        )
+
+        XCTAssertFalse(uploaded.key.isEmpty)
+        XCTAssertEqual(uploaded.bucket, testBucketName)
+        print("✅ Chunked data upload: \(uploaded.key)")
+    }
+
+    /// Test memory-efficient chunked upload from a local file URL
+    func testChunkedUploadFromFileURL() async throws {
+        print("🔵 Testing chunked upload (fileURL)...")
+
+        try? await insForgeClient.storage.deleteBucket(testBucketName)
+        try await insForgeClient.storage.createBucket(
+            testBucketName,
+            options: BucketOptions(isPublic: true)
+        )
+
+        let fileApi = await insForgeClient.storage.from(testBucketName)
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let tempFile = tempDir.appendingPathComponent("chunk-url-\(UUID().uuidString).txt")
+        let content = String(repeating: "B", count: 2048)
+        try content.write(to: tempFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tempFile) }
+
+        let filePath = "chunked-url-\(UUID().uuidString).txt"
+        let uploaded = try await fileApi.uploadChunked(
+            path: filePath,
+            fileURL: tempFile,
+            options: ChunkedUploadOptions(
+                chunkSize: 512,
+                fileOptions: FileOptions(contentType: "text/plain")
+            )
+        )
+
+        XCTAssertFalse(uploaded.key.isEmpty)
+        XCTAssertEqual(uploaded.bucket, testBucketName)
+        print("✅ Chunked file URL upload: \(uploaded.key)")
+    }
+
     /// Test complete workflow: create bucket -> upload -> list -> download -> delete file -> delete bucket
     func testCompleteWorkflow() async throws {
         print("🔵 Testing complete storage workflow...")


### PR DESCRIPTION
## Summary

Closes #9

- Add `ChunkedUploadOptions` struct with configurable `chunkSize` (default 5 MB, minimum 1 byte)
- Add `uploadChunked(path:data:options:)` — splits `Data` into sequential chunks uploaded via `Content-Range` headers
- Add `uploadChunked(path:fileURL:options:)` — memory-efficient variant using `FileHandle` to read and send one chunk at a time without loading the full file into memory
- Token refresh on 401 per chunk, consistent with the rest of the storage module

## What changed

**`Sources/Storage/StorageClient.swift`** (+230 lines)
- `ChunkedUploadOptions` struct added alongside existing options types
- `uploadChunked(path:data:options:)` added to `StorageFileApi`
- `uploadChunked(path:fileURL:options:)` added to `StorageFileApi`
- `uploadChunk(...)` private helper with 401 token-refresh retry

**`Tests/InsForgeStorageTests/InsForgeStorageTests.swift`** (+84 lines)
- 3 pure unit tests for `ChunkedUploadOptions` (no network required)
- 2 integration tests covering both upload variants with small chunk sizes to force multiple chunk requests

## Test plan

- [x] `testChunkedUploadOptionsDefaults` — verifies default chunk size (5 MB) and nil content type
- [x] `testChunkedUploadOptionsCustom` — verifies custom chunk size and content type are set correctly
- [x] `testChunkedUploadOptionsClampedChunkSize` — verifies `chunkSize: 0` is clamped to 1
- [x] `testChunkedUploadData` — integration test, uploads 1 KB with 256-byte chunks to force multiple chunk requests
- [x] `testChunkedUploadFromFileURL` — integration test, uploads from a temp file URL with 512-byte chunks via `FileHandle`
