### PR TITLE
feat(functions): add direct functions URL support with fallback to proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ let downloadStrategy = try await client.storage
 ### Functions
 
 ```swift
+import InsForge
+import InsForgeFunctions
+
 // Invoke a function
 struct GreetingRequest: Codable {
     let name: String
@@ -185,6 +188,26 @@ let response: GreetingResponse = try await client.functions.invoke(
     body: GreetingRequest(name: "Alice")
 )
 print(response.message) // "Hello, Alice!"
+
+// Invoke a function with a custom method and headers
+let getResponse: GreetingResponse = try await client.functions.invoke(
+    "hello-world",
+    options: FunctionInvokeOptions(
+        method: .get,
+        headers: ["X-Trace-ID": UUID().uuidString]
+    )
+)
+
+// Configure a direct functions URL and fall back to the proxy on 404
+let directFunctionsClient = InsForgeClient(
+    baseURL: URL(string: "https://your-project.insforge.app")!,
+    anonKey: "your-anon-key",
+    options: InsForgeClientOptions(
+        functions: .init(
+            url: URL(string: "https://your-project.functions.insforge.app")!
+        )
+    )
+)
 ```
 
 ### AI
@@ -252,6 +275,9 @@ await client.realtime.disconnect()
 ## Advanced Configuration
 
 ```swift
+import InsForge
+import InsForgeFunctions
+
 let client = InsForgeClient(
     baseURL: URL(string: "https://your-project.insforge.com")!,
     anonKey: "your-anon-key",

--- a/Sources/Core/HTTPClient.swift
+++ b/Sources/Core/HTTPClient.swift
@@ -23,7 +23,7 @@ public protocol TokenRefreshHandler: Sendable {
 }
 
 /// HTTP method types supported by the client.
-public enum HTTPMethod: String {
+public enum HTTPMethod: String, Sendable {
     /// HTTP GET method.
     case get = "GET"
     /// HTTP POST method.

--- a/Sources/Functions/FunctionsClient.swift
+++ b/Sources/Functions/FunctionsClient.swift
@@ -2,9 +2,44 @@ import Foundation
 import InsForgeCore
 import Logging
 
+/// Configuration options for the functions client.
+public struct FunctionsOptions: Sendable {
+    /// Direct functions/subhosting URL to try before the proxy URL.
+    public let url: URL?
+
+    /// Whether to derive and try the default `.functions.insforge.app` host when no explicit URL is provided.
+    public let useSubhosting: Bool
+
+    public init(
+        url: URL? = nil,
+        useSubhosting: Bool = true
+    ) {
+        self.url = url
+        self.useSubhosting = useSubhosting
+    }
+}
+
+/// Per-request options for function invocation.
+public struct FunctionInvokeOptions: Sendable {
+    /// HTTP method to use when invoking the function.
+    public let method: HTTPMethod
+
+    /// Additional headers to include with the request.
+    public let headers: [String: String]
+
+    public init(
+        method: HTTPMethod = .post,
+        headers: [String: String] = [:]
+    ) {
+        self.method = method
+        self.headers = headers
+    }
+}
+
 /// Functions client for invoking serverless functions
 public actor FunctionsClient {
     private let url: URL
+    private let directURL: URL?
     private let headersProvider: LockIsolated<[String: String]>
     private let httpClient: HTTPClient
     private let tokenRefreshHandler: (any TokenRefreshHandler)?
@@ -17,10 +52,12 @@ public actor FunctionsClient {
 
     public init(
         url: URL,
+        directURL: URL? = nil,
         headersProvider: LockIsolated<[String: String]>,
         tokenRefreshHandler: (any TokenRefreshHandler)? = nil
     ) {
         self.url = url
+        self.directURL = directURL
         self.headersProvider = headersProvider
         self.httpClient = HTTPClient()
         self.tokenRefreshHandler = tokenRefreshHandler
@@ -51,111 +88,115 @@ public actor FunctionsClient {
         }
     }
 
+    private func makeRequestHeaders(options: FunctionInvokeOptions, hasBody: Bool) -> [String: String] {
+        var requestHeaders = headers.merging(options.headers) { _, newValue in newValue }
+        if hasBody, requestHeaders["Content-Type"] == nil {
+            requestHeaders["Content-Type"] = "application/json"
+        }
+        return requestHeaders
+    }
+
+    private func performInvocationRequest(
+        method: HTTPMethod,
+        url endpoint: URL,
+        headers: [String: String],
+        body: Data?
+    ) async throws -> HTTPResponse {
+        logger.debug("\(method.rawValue) \(endpoint.absoluteString)")
+        logger.trace("Request headers: \(headers.filter { $0.key != "Authorization" })")
+        if let body, let bodyString = String(data: body, encoding: .utf8) {
+            logger.trace("Request body: \(bodyString)")
+        }
+
+        let response = try await executeRequest(
+            method,
+            url: endpoint,
+            headers: headers,
+            body: body
+        )
+
+        logger.debug("Response: \(response.response.statusCode)")
+        if let responseString = String(data: response.data, encoding: .utf8), !responseString.isEmpty {
+            logger.trace("Response body: \(responseString)")
+        }
+
+        return response
+    }
+
+    private func invokeFunction(
+        _ slug: String,
+        options: FunctionInvokeOptions,
+        body: Data?
+    ) async throws -> HTTPResponse {
+        let requestHeaders = makeRequestHeaders(options: options, hasBody: body != nil)
+
+        if let directURL {
+            let directEndpoint = directURL.appendingPathComponent(slug)
+            do {
+                return try await performInvocationRequest(
+                    method: options.method,
+                    url: directEndpoint,
+                    headers: requestHeaders,
+                    body: body
+                )
+            } catch let error as InsForgeError {
+                if case .httpError(let statusCode, _, _, _) = error, statusCode == 404 {
+                    logger.debug("Direct function route returned 404, falling back to proxy URL")
+                } else {
+                    throw error
+                }
+            }
+        }
+
+        let proxyEndpoint = url.appendingPathComponent(slug)
+        return try await performInvocationRequest(
+            method: options.method,
+            url: proxyEndpoint,
+            headers: requestHeaders,
+            body: body
+        )
+    }
+
     /// Invoke a function
     public func invoke<T: Decodable>(
         _ slug: String,
+        options: FunctionInvokeOptions = FunctionInvokeOptions(),
         body: [String: Any]? = nil
     ) async throws -> T {
-        let endpoint = url.appendingPathComponent(slug)
-
         var requestBody: Data?
         if let body = body {
             requestBody = try JSONSerialization.data(withJSONObject: body)
         }
 
-        let requestHeaders = headers.merging(["Content-Type": "application/json"]) { $1 }
-
-        // Log request
-        logger.debug("POST \(endpoint.absoluteString)")
-        logger.trace("Request headers: \(requestHeaders.filter { $0.key != "Authorization" })")
-        if let requestBody = requestBody, let bodyString = String(data: requestBody, encoding: .utf8) {
-            logger.trace("Request body: \(bodyString)")
-        }
-
-        let response = try await executeRequest(
-            .post,
-            url: endpoint,
-            headers: requestHeaders,
-            body: requestBody
-        )
-
-        // Log response
-        let statusCode = response.response.statusCode
-        logger.debug("Response: \(statusCode)")
-        if let responseString = String(data: response.data, encoding: .utf8) {
-            logger.trace("Response body: \(responseString)")
-        }
-
+        let response = try await invokeFunction(slug, options: options, body: requestBody)
         return try response.decode(T.self)
     }
 
     /// Invoke a function with Encodable body
     public func invoke<I: Encodable, O: Decodable>(
         _ slug: String,
+        options: FunctionInvokeOptions = FunctionInvokeOptions(),
         body: I
     ) async throws -> O {
-        let endpoint = url.appendingPathComponent(slug)
-
         let encoder = JSONEncoder()
         let requestBody = try encoder.encode(body)
 
-        let requestHeaders = headers.merging(["Content-Type": "application/json"]) { $1 }
-
-        // Log request
-        logger.debug("POST \(endpoint.absoluteString)")
-        logger.trace("Request headers: \(requestHeaders.filter { $0.key != "Authorization" })")
-        if let bodyString = String(data: requestBody, encoding: .utf8) {
-            logger.trace("Request body: \(bodyString)")
-        }
-
-        let response = try await executeRequest(
-            .post,
-            url: endpoint,
-            headers: requestHeaders,
-            body: requestBody
-        )
-
-        // Log response
-        let statusCode = response.response.statusCode
-        logger.debug("Response: \(statusCode)")
-        if let responseString = String(data: response.data, encoding: .utf8) {
-            logger.trace("Response body: \(responseString)")
-        }
-
+        let response = try await invokeFunction(slug, options: options, body: requestBody)
         let decoder = JSONDecoder()
         return try decoder.decode(O.self, from: response.data)
     }
 
     /// Invoke a function without expecting a response body
-    public func invoke(_ slug: String, body: [String: Any]? = nil) async throws {
-        let endpoint = url.appendingPathComponent(slug)
-
+    public func invoke(
+        _ slug: String,
+        options: FunctionInvokeOptions = FunctionInvokeOptions(),
+        body: [String: Any]? = nil
+    ) async throws {
         var requestBody: Data?
         if let body = body {
             requestBody = try JSONSerialization.data(withJSONObject: body)
         }
 
-        let requestHeaders = headers.merging(["Content-Type": "application/json"]) { $1 }
-
-        // Log request
-        logger.debug("POST \(endpoint.absoluteString)")
-        logger.trace("Request headers: \(requestHeaders.filter { $0.key != "Authorization" })")
-        if let requestBody = requestBody, let bodyString = String(data: requestBody, encoding: .utf8) {
-            logger.trace("Request body: \(bodyString)")
-        }
-
-        let response = try await executeRequest(
-            .post,
-            url: endpoint,
-            headers: requestHeaders,
-            body: requestBody
-        )
-
-        // Log response
-        let statusCode = response.response.statusCode
-        logger.debug("Response: \(statusCode)")
-        if let responseString = String(data: response.data, encoding: .utf8), !responseString.isEmpty {
-            logger.trace("Response body: \(responseString)")
-        }
+        _ = try await invokeFunction(slug, options: options, body: requestBody)
     }
 }

--- a/Sources/InsForge/InsForgeClient.swift
+++ b/Sources/InsForge/InsForgeClient.swift
@@ -58,6 +58,9 @@ public final class InsForgeClient: Sendable {
     /// Token refresh handler for automatic 401 retry
     private let _tokenRefreshHandler: AuthTokenRefreshHandler
 
+    /// Direct functions URL used for subhosting-first invocation.
+    private let directFunctionsURL: URL?
+
     // MARK: - Sub-clients
 
     private let _auth: AuthClient
@@ -118,6 +121,7 @@ public final class InsForgeClient: Sendable {
             authClient: self._auth,
             headersProvider: self._headers
         )
+        self.directFunctionsURL = Self.resolveFunctionsURL(baseURL: baseURL, options: options.functions)
 
         // Capture logger for use in closure
         let log = self.logger
@@ -191,6 +195,7 @@ public final class InsForgeClient: Sendable {
             if state.functions == nil {
                 state.functions = FunctionsClient(
                     url: baseURL.appendingPathComponent("functions"),
+                    directURL: directFunctionsURL,
                     headersProvider: _headers,
                     tokenRefreshHandler: _tokenRefreshHandler
                 )
@@ -233,4 +238,30 @@ public final class InsForgeClient: Sendable {
     // MARK: - Version
 
     static let version = "0.0.6"
+
+    private static func resolveFunctionsURL(baseURL: URL, options: FunctionsOptions) -> URL? {
+        if let url = options.url {
+            return url
+        }
+
+        guard options.useSubhosting else {
+            return nil
+        }
+
+        guard let host = baseURL.host, host.hasSuffix(".insforge.app") else {
+            return nil
+        }
+
+        let hostComponents = host.split(separator: ".")
+        guard let appKey = hostComponents.first, !appKey.isEmpty else {
+            return nil
+        }
+
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)
+        components?.host = "\(appKey).functions.insforge.app"
+        components?.path = ""
+        components?.query = nil
+        components?.fragment = nil
+        return components?.url
+    }
 }

--- a/Sources/InsForge/InsForgeClientOptions.swift
+++ b/Sources/InsForge/InsForgeClientOptions.swift
@@ -2,6 +2,7 @@ import Foundation
 import InsForgeCore
 import InsForgeAuth
 import InsForgeDatabase
+import InsForgeFunctions
 import Logging
 
 /// Configuration options for InsForge client
@@ -59,6 +60,7 @@ public struct InsForgeClientOptions: Sendable {
 
     public let database: InsForgeDatabase.DatabaseOptions
     public let auth: InsForgeAuth.AuthOptions
+    public let functions: InsForgeFunctions.FunctionsOptions
     public let global: GlobalOptions
 
     // MARK: - Initialization
@@ -66,10 +68,12 @@ public struct InsForgeClientOptions: Sendable {
     public init(
         database: InsForgeDatabase.DatabaseOptions = .init(),
         auth: InsForgeAuth.AuthOptions = .init(),
+        functions: InsForgeFunctions.FunctionsOptions = .init(),
         global: GlobalOptions = .init()
     ) {
         self.database = database
         self.auth = auth
+        self.functions = functions
         self.global = global
     }
 }

--- a/Tests/InsForgeFunctionsTests/InsForgeFunctionsTests.swift
+++ b/Tests/InsForgeFunctionsTests/InsForgeFunctionsTests.swift
@@ -34,6 +34,29 @@ final class InsForgeFunctionsTests: XCTestCase {
         insForgeClient = nil
     }
 
+    private func derivedFunctionsURL() throws -> URL {
+        guard let host = TestHelper.baseURL.host else {
+            throw XCTSkip("Test base URL has no host")
+        }
+
+        let hostComponents = host.split(separator: ".")
+        guard let appKey = hostComponents.first else {
+            throw XCTSkip("Could not derive functions URL from host")
+        }
+
+        var components = URLComponents(url: TestHelper.baseURL, resolvingAgainstBaseURL: false)
+        components?.host = "\(appKey).functions.insforge.app"
+        components?.path = ""
+        components?.query = nil
+        components?.fragment = nil
+
+        guard let url = components?.url else {
+            throw XCTSkip("Could not construct functions URL")
+        }
+
+        return url
+    }
+
     // MARK: - Tests
 
     func testFunctionsClientInitialization() async {
@@ -132,6 +155,40 @@ final class InsForgeFunctionsTests: XCTestCase {
                 throw error
             }
         }
+    }
+
+    /// Test invoking a function with a custom HTTP method.
+    func testInvokeHelloFunctionWithGETMethod() async throws {
+        struct HelloResponse: Decodable {
+            let message: String
+        }
+
+        let response: HelloResponse = try await insForgeClient.functions.invoke(
+            "hello",
+            options: FunctionInvokeOptions(method: .get)
+        )
+
+        XCTAssertFalse(response.message.isEmpty)
+        print("✅ Hello function GET response: \(response.message)")
+    }
+
+    /// Test invoking through an explicit subhosting URL and falling back to the proxy on 404.
+    func testInvokeHelloFunctionWithSubhostingFallback() async throws {
+        struct HelloResponse: Decodable {
+            let message: String
+        }
+
+        let client = TestHelper.createClient(
+            options: InsForgeClientOptions(
+                functions: FunctionsOptions(
+                    url: try derivedFunctionsURL()
+                )
+            )
+        )
+
+        let response: HelloResponse = try await client.functions.invoke("hello")
+        XCTAssertFalse(response.message.isEmpty)
+        print("✅ Hello function with subhosting fallback response: \(response.message)")
     }
 
     /// Test error handling for non-existent function


### PR DESCRIPTION
- Introduce FunctionsOptions with direct URL and subhosting options
- Update FunctionsClient to try direct URL and fallback on 404 errors
- Add FunctionInvokeOptions for custom HTTP methods and headers per request
- Modify InsForgeClient to resolve and use direct functions URL automatically
- Enhance invoke methods to accept FunctionInvokeOptions and support GET method
- Extend documentation with examples for function invocation and configuration
- Add tests for GET method invocation and subhosting fallback functionality
- Mark HTTPMethod enum as Sendable for concurrency safety
- Refactor request creation and logging in FunctionsClient for clarity and flexibility

Closes #19 