### PR TITLE
fix(lint): resolve pre-existing SwiftLint violations

### DIFF
--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -443,6 +443,12 @@ public final class RealtimeClient: @unchecked Sendable {
 
     // MARK: - Connection
 
+    private struct ConnectInvocation {
+        let task: Task<Void, Error>
+        let token: UUID
+        let isOwner: Bool
+    }
+
     /// Connect to the realtime server
     public func connect() async throws {
         try await connect(resetRetryBudget: true)
@@ -457,12 +463,12 @@ public final class RealtimeClient: @unchecked Sendable {
 
         cancelReconnectTask()
 
-        let invocation = reconnectCoordinator.withValue { coordinator -> (task: Task<Void, Error>, token: UUID, isOwner: Bool) in
+        let invocation = reconnectCoordinator.withValue { coordinator -> ConnectInvocation in
             coordinator.runtime.prepareForConnectionRequest(resetRetryAttempt: resetRetryBudget)
 
             if let existingTask = coordinator.connectTask,
                let existingToken = coordinator.connectTaskToken {
-                return (existingTask, existingToken, false)
+                return ConnectInvocation(task: existingTask, token: existingToken, isOwner: false)
             }
 
             let token = UUID()
@@ -473,7 +479,7 @@ public final class RealtimeClient: @unchecked Sendable {
 
             coordinator.connectTask = task
             coordinator.connectTaskToken = token
-            return (task, token, true)
+            return ConnectInvocation(task: task, token: token, isOwner: true)
         }
 
         do {

--- a/Tests/InsForgeCoreTests/ErrorHandlingTests.swift
+++ b/Tests/InsForgeCoreTests/ErrorHandlingTests.swift
@@ -8,8 +8,8 @@ private final class MockURLProtocol: URLProtocol {
     /// Set this before each test to control what response the mock returns.
     static var responseHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
-    override class func canInit(with request: URLRequest) -> Bool { true }
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override static func canInit(with request: URLRequest) -> Bool { true }
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
         guard let handler = MockURLProtocol.responseHandler else {
@@ -49,7 +49,7 @@ private func makeResponse(statusCode: Int, headers: [String: String] = [:]) -> H
 private func emptyData() -> Data { Data() }
 
 private func errorJSON(_ message: String = "error") -> Data {
-    try! JSONEncoder().encode(["message": message, "error": "test_error"])
+    (try? JSONEncoder().encode(["message": message, "error": "test_error"])) ?? Data()
 }
 
 // MARK: - NetworkError Tests


### PR DESCRIPTION
## Summary

Fixes 4 pre-existing SwiftLint violations that were causing CI to fail 
with `--strict` mode. None of these were introduced by recent PRs.

- `Tests/InsForgeCoreTests/ErrorHandlingTests.swift:52` — replaced `try!` 
  with `(try? ...) ?? Data()` to fix `force_try` violation
- `Tests/InsForgeCoreTests/ErrorHandlingTests.swift:11-12` — replaced 
  `override class func` with `override static func` in `final class MockURLProtocol` 
  to fix `static_over_final_class` violation
- `Sources/Realtime/RealtimeClient.swift:460` — extracted 3-member tuple 
  `(task:token:isOwner:)` into private `ConnectInvocation` struct to fix 
  `large_tuple` violation

Closes #24

## Test plan
- [x] CI SwiftLint passes with `--strict`
- [x] All existing tests continue to pass