### PR TITLE
ci: automate Swift SDK releases

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,65 +1,112 @@
-name: Swift CI
+name: Swift CI and Release
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
+    tags:
+      - "*.*.*"
   pull_request:
-    branches: [ main ]
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   build-macos:
-    name: Build on macOS
+    name: Build and test
     runs-on: macos-14
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-    - name: Setup Swift
-      uses: swift-actions/setup-swift@v2
-      with:
-        swift-version: '5.9'
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2.4.0
+        with:
+          swift-version: "5.9"
 
-    - name: Cache Swift Packages
-      uses: actions/cache@v4
-      with:
-        path: .build
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-spm-
+      - name: Cache Swift packages
+        uses: actions/cache@v6.1.0
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
-    - name: Build
-      run: swift build -v
+      - name: Validate release tag
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Tag must be a stable or prerelease SemVer without a v prefix: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+          sdk_version=$(sed -n 's/.*static let version = "\([^"]*\)".*/\1/p' Sources/InsForge/InsForgeClient.swift)
+          if [[ "$sdk_version" != "$RELEASE_TAG" ]]; then
+            echo "Tag $RELEASE_TAG does not match SDK version $sdk_version" >&2
+            exit 1
+          fi
+
+      - name: Build
+        run: swift build -v
+
+      - name: Run deterministic tests
+        run: ./scripts/test-unit.sh
 
   lint:
     name: SwiftLint
     runs-on: macos-14
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-    - name: SwiftLint
-      run: |
-        brew install swiftlint
-        swiftlint lint --strict
+      - name: SwiftLint
+        run: |
+          brew install swiftlint
+          swiftlint lint --strict
 
   build-documentation:
     name: Build Documentation
     runs-on: macos-14
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-    - name: Build DocC
-      run: |
-        swift package --allow-writing-to-directory ./docs \
-          generate-documentation --target InsForge \
-          --output-path ./docs \
-          --transform-for-static-hosting \
-          --hosting-base-path insforge-swift
+      - name: Build DocC
+        run: |
+          swift package --allow-writing-to-directory ./docs \
+            generate-documentation --target InsForge \
+            --output-path ./docs \
+            --transform-for-static-hosting \
+            --hosting-base-path insforge-swift
 
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+
+  release:
+    name: Create stable GitHub Release
+    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
+    needs: [build-macos, lint]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if gh release view "$RELEASE_TAG" --repo "$REPOSITORY" >/dev/null 2>&1; then
+            echo "GitHub Release $RELEASE_TAG already exists"
+          else
+            gh release create "$RELEASE_TAG" --repo "$REPOSITORY" --generate-notes --verify-tag
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -319,9 +319,14 @@ Only maintainers can release new versions:
 1. Update `CHANGELOG.md`
 2. Update version number in `Sources/InsForge/InsForgeClient.swift`
 3. Create PR and merge
-4. Create tag: `git tag -a 1.0.1 -m "Release 1.0.1"`
-5. Push tag: `git push origin 1.0.1`
-6. Create Release on GitHub
+4. Create a tag without a `v` prefix: `git tag -a <version> -m "Release <version>"`
+5. Push the tag: `git push origin <version>`
+
+The tag immediately makes the version available to Swift Package Manager. The
+release workflow validates that the tag matches the SDK version and creates a
+GitHub Release only for stable tags. Prerelease tags such as `0.1.0-beta.1` are
+validated and remain available to Swift Package Manager without creating a
+GitHub Release.
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add the following to your `Package.swift` file:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InsForge/insforge-swift.git", from: "1.0.0")
+    .package(url: "https://github.com/InsForge/insforge-swift.git", from: "0.0.10")
 ]
 ```
 

--- a/Sources/InsForge/InsForgeClient.swift
+++ b/Sources/InsForge/InsForgeClient.swift
@@ -238,5 +238,5 @@ public final class InsForgeClient: Sendable {
 
     // MARK: - Version
 
-    static let version = "0.0.6"
+    static let version = "0.0.10"
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,7 +7,7 @@
 #   ./scripts/release.sh 1.0.1
 #   ./scripts/release.sh 1.1.0 --dry-run
 
-set -e
+set -euo pipefail
 
 # Colors for output
 RED='\033[0;31m'
@@ -26,14 +26,14 @@ fi
 VERSION=$1
 DRY_RUN=false
 
-if [ "$2" == "--dry-run" ]; then
+if [ "${2:-}" == "--dry-run" ]; then
     DRY_RUN=true
     echo -e "${YELLOW}Running in DRY RUN mode - no changes will be made${NC}"
 fi
 
-# Validate version format (semver)
-if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo -e "${RED}Error: Invalid version format. Use semver (e.g., 1.0.1)${NC}"
+# Validate stable or prerelease SemVer (without a v prefix)
+if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+    echo -e "${RED}Error: Invalid version format. Use semver without a v prefix (e.g., 1.0.1 or 1.1.0-beta.1)${NC}"
     exit 1
 fi
 
@@ -63,7 +63,7 @@ fi
 
 # Run tests
 echo -e "${GREEN}Running tests...${NC}"
-swift test
+./scripts/test-unit.sh
 
 # Run SwiftLint
 echo -e "${GREEN}Running SwiftLint...${NC}"
@@ -114,48 +114,12 @@ else
     echo "Would push: git push origin $VERSION"
 fi
 
-# Create GitHub release
-echo -e "${GREEN}Creating GitHub release...${NC}"
-if command -v gh &> /dev/null; then
-    if [ "$DRY_RUN" = false ]; then
-        # Extract release notes from CHANGELOG
-        RELEASE_NOTES=$(awk "/## \[$VERSION\]/,/## \[.*\]/{if (/## \[$VERSION\]/) next; if (/## \[.*\]/) exit; print}" CHANGELOG.md)
-
-        gh release create "$VERSION" \
-            --title "v$VERSION" \
-            --notes "$RELEASE_NOTES"
-    else
-        echo "Would create GitHub release for version $VERSION"
-    fi
-else
-    echo -e "${YELLOW}Warning: GitHub CLI (gh) not installed${NC}"
-    echo "Please create the release manually at:"
-    echo "https://github.com/YOUR_ORG/insforge-swift/releases/new?tag=$VERSION"
-fi
-
-# Optional: Publish to CocoaPods
-echo -e "${GREEN}Do you want to publish to CocoaPods? (y/n)${NC}"
-read -r PUBLISH_COCOAPODS
-
-if [ "$PUBLISH_COCOAPODS" = "y" ]; then
-    if command -v pod &> /dev/null; then
-        echo -e "${GREEN}Publishing to CocoaPods...${NC}"
-        if [ "$DRY_RUN" = false ]; then
-            pod trunk push InsForge.podspec --allow-warnings
-        else
-            echo "Would run: pod trunk push InsForge.podspec --allow-warnings"
-        fi
-    else
-        echo -e "${YELLOW}Warning: CocoaPods not installed${NC}"
-    fi
-fi
-
 echo -e "${GREEN}✅ Release process completed successfully!${NC}"
 echo ""
 echo "Next steps:"
-echo "1. Verify the release on GitHub"
+echo "1. Verify the release workflow on GitHub Actions"
 echo "2. Update documentation site"
 echo "3. Announce the release on social media"
 echo "4. Monitor for any issues"
 echo ""
-echo "Release URL: https://github.com/YOUR_ORG/insforge-swift/releases/tag/$VERSION"
+echo "Tag URL: https://github.com/InsForge/insforge-swift/tree/$VERSION"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,7 +16,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Check if version argument is provided
-if [ -z "$1" ]; then
+if [ -z "${1:-}" ]; then
     echo -e "${RED}Error: Version number required${NC}"
     echo "Usage: $0 <version> [--dry-run]"
     echo "Example: $0 1.0.1"
@@ -34,6 +34,12 @@ fi
 # Validate stable or prerelease SemVer (without a v prefix)
 if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
     echo -e "${RED}Error: Invalid version format. Use semver without a v prefix (e.g., 1.0.1 or 1.1.0-beta.1)${NC}"
+    exit 1
+fi
+
+# This script pauses for the maintainer to update CHANGELOG.md.
+if [ ! -t 0 ]; then
+    echo -e "${RED}Error: This release script requires an interactive terminal${NC}"
     exit 1
 fi
 
@@ -84,7 +90,7 @@ fi
 # Update CHANGELOG.md
 echo -e "${GREEN}Please update CHANGELOG.md with release notes${NC}"
 echo "Press enter when done..."
-read
+read -r
 
 if [ "$DRY_RUN" = false ]; then
     git add CHANGELOG.md

--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Live integration tests share test classes with model tests today. Keep CI
+# deterministic by excluding the classes/method that call a real backend.
+# Run `swift test` directly when intentionally exercising that backend.
+swift test \
+    --skip 'InsForgeAITests\.InsForgeAITests' \
+    --skip 'InsForgeAITests\.ToolCallingTests/testChatCompletionWithToolCalling' \
+    --skip 'InsForgeFunctionsTests\.InsForgeFunctionsTests' \
+    --skip 'InsForgeRealtimeTests\.InsForgeRealtimeTests' \
+    --skip 'InsForgeStorageTests\.InsForgeStorageTests'


### PR DESCRIPTION
## Summary

- validate stable and prerelease SemVer tags against the SDK runtime version
- run 152 deterministic tests in CI while keeping live-backend integration tests explicit
- create GitHub Releases only for stable tags; prerelease tags remain consumable by Swift Package Manager
- update release docs/script and correct the current package/runtime version references

## Verification

- `./scripts/test-unit.sh` (152 tests, 0 failures)
- `swiftlint lint --strict` (0 violations)
- `actionlint`
- shell syntax and stable/prerelease/invalid tag cases

No registry credentials, environment, or repository secrets are required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates Swift SDK releases in CI with SemVer tag validation, deterministic tests, and a safer release script. Stable tags auto-create GitHub Releases; prereleases validate and remain available via Swift Package Manager.

- **New Features**
  - Validate SemVer tags (no `v` prefix) against `InsForgeClient.version` on tag builds.
  - Create GitHub Releases only for stable tags; prereleases (e.g., `0.1.0-beta.1`) are validated but not released.
  - Run 152 deterministic unit tests in CI via `scripts/test-unit.sh`; live-backend tests stay opt-in.
  - Harden `scripts/release.sh` with prerelease SemVer support, strict error handling, and an interactive terminal check.

- **Migration**
  - Tag versions without a `v` prefix (e.g., `0.0.10`) that match `InsForgeClient.version`.
  - Use `swift test` for live integration tests; run `scripts/release.sh` from an interactive terminal.

<sup>Written for commit b1f40c739f71f6ddd1ee46f412cb84a98b46eb4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-swift/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

