### PR TITLE
ci: pin release workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: macos-14
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Swift
-        uses: swift-actions/setup-swift@v2.4.0
+        uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
         with:
           swift-version: "5.9"
 
       - name: Cache Swift packages
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
@@ -59,7 +59,7 @@ jobs:
     runs-on: macos-14
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: SwiftLint
         run: |
@@ -74,7 +74,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Build DocC
         run: |
@@ -85,7 +85,7 @@ jobs:
             --hosting-base-path insforge-swift
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4.1.0
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs


### PR DESCRIPTION
## Summary

- pin every external action in the combined Swift CI/release workflow to a full commit SHA
- retain version comments for readability and automated updates
- leave Swift tag validation and stable GitHub Release behavior unchanged

## Validation

- `actionlint .github/workflows/swift.yml`
- SwiftLint strict mode: 0 violations
- `swift build -v`
- `./scripts/test-unit.sh`: 152 tests passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin external GitHub Actions in the Swift CI/release workflow to full commit SHAs for reproducible, secure builds. Added Dependabot to track and update Actions weekly; tag validation and GitHub Pages release behavior are unchanged.

- **Dependencies**
  - Pinned `actions/checkout`, `swift-actions/setup-swift`, `actions/cache`, and `peaceiris/actions-gh-pages` to specific SHAs (kept version comments).
  - Added `.github/dependabot.yml` to enable weekly updates for GitHub Actions.

<sup>Written for commit 72af4b5d92aaf934648e36fc35b105375e1fe385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-swift/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

