### PR TITLE
Sync with InsForge-sdk-js v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Realtime auto-reconnect with bounded exponential backoff (max attempts + jitter), automatic channel re-subscription on reconnect, and `NWPathMonitor`-based network-aware retry behavior.
 - Configurable realtime reconnect policy and connection timeout via `InsForgeClientOptions.realtime`.
 
+### Changed
+- **Storage: standard PUT create-or-replace semantics** (sync with InsForge-sdk-js v1.5.0, requires an InsForge backend that includes InsForge/InsForge#1760):
+  - `upload(path:data:options:)` / `upload(path:fileURL:options:)` — uploading to a key that already exists now replaces the object in place. Previously the server silently auto-renamed the key (`photo.png` → `photo (1).png`). The method signatures are unchanged.
+  - `upload(data:fileName:options:)` — now generates a unique, collision-free key client-side (sanitized base + timestamp + random suffix) and uploads through the standard `upload(path:data:options:)` path, so repeated uploads of the same file never overwrite each other.
+
 ### Planned
 - Streaming support for AI chat completion
 - Batch operations for database

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ try await client.database
 try await client.storage.createBucket("avatars", options: BucketOptions(isPublic: true))
 
 // Upload a file with specific path
+// (replaces the existing object when the path is already in use)
 let imageData = // ... your image data
 let file = try await client.storage
     .from("avatars")
@@ -129,7 +130,8 @@ let file = try await client.storage
         options: FileOptions(contentType: "image/jpeg")
     )
 
-// Upload with auto-generated key
+// Upload with auto-generated, collision-free key
+// (derived client-side from the filename, so repeated uploads never overwrite)
 let autoFile = try await client.storage
     .from("avatars")
     .upload(

--- a/Sources/Storage/StorageClient.swift
+++ b/Sources/Storage/StorageClient.swift
@@ -366,9 +366,48 @@ public struct StorageFileApi: Sendable {
         self.tokenRefreshHandler = tokenRefreshHandler
     }
 
+    // MARK: - Object Key Generation
+
+    /// Generate a unique object key from a filename: `<sanitized-base>-<timestamp>-<random><ext>`.
+    /// Auto-key generation is a client-side convenience — the storage API has no
+    /// server-side key minting — so `upload(data:fileName:options:)` produces the
+    /// key here and then uploads through the standard `upload(path:data:options:)` path.
+    static func generateObjectKey(from filename: String) -> String {
+        let ext: String
+        let base: String
+        if let dotIndex = filename.lastIndex(of: "."), dotIndex != filename.startIndex {
+            ext = String(filename[dotIndex...])
+            base = String(filename[..<dotIndex])
+        } else {
+            ext = ""
+            base = filename
+        }
+
+        let sanitized = String(
+            base.map { char -> Character in
+                let isAllowed = ("a"..."z").contains(char)
+                    || ("A"..."Z").contains(char)
+                    || ("0"..."9").contains(char)
+                    || char == "-"
+                    || char == "_"
+                return isAllowed ? char : "-"
+            }.prefix(32)
+        )
+        let sanitizedBase = sanitized.isEmpty ? "file" : sanitized
+
+        let timestamp = Int(Date().timeIntervalSince1970 * 1000)
+        let alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+        let random = String((0..<6).compactMap { _ in alphabet.randomElement() })
+
+        return "\(sanitizedBase)-\(timestamp)-\(random)\(ext)"
+    }
+
     // MARK: - Upload
 
     /// Uploads a file to the bucket with a specific key using presigned URL flow.
+    ///
+    /// Standard PUT semantics: uploading to a key that already exists replaces
+    /// the current object in place.
     /// - Parameters:
     ///   - path: The object key (can include forward slashes for pseudo-folders).
     ///   - data: The file data to upload.
@@ -413,6 +452,9 @@ public struct StorageFileApi: Sendable {
     }
 
     /// Uploads a file from a local file URL.
+    ///
+    /// Standard PUT semantics: uploading to a key that already exists replaces
+    /// the current object in place.
     /// - Parameters:
     ///   - path: The object key.
     ///   - fileURL: The local file URL to upload.
@@ -428,7 +470,12 @@ public struct StorageFileApi: Sendable {
         return try await upload(path: path, data: data, options: options)
     }
 
-    /// Uploads a file with auto-generated key using presigned URL flow.
+    /// Uploads a file under an automatically generated, collision-free key.
+    ///
+    /// The key is derived client-side from the filename (sanitized base +
+    /// timestamp + random suffix) and uploaded through the standard
+    /// `upload(path:data:options:)` path, so repeated uploads of the same file
+    /// never overwrite each other.
     /// - Parameters:
     ///   - data: The file data to upload.
     ///   - fileName: Original filename for generating the key.
@@ -440,36 +487,11 @@ public struct StorageFileApi: Sendable {
         fileName: String,
         options: FileOptions = FileOptions()
     ) async throws -> StoredFile {
-        let contentType = options.contentType ?? inferContentType(from: fileName)
-
-        // 1. Get upload strategy (auto-generates key)
-        let strategy = try await getUploadStrategy(
-            filename: fileName,
-            contentType: contentType,
-            size: data.count
+        try await upload(
+            path: Self.generateObjectKey(from: fileName),
+            data: data,
+            options: options
         )
-
-        // 2. Upload to presigned URL or direct endpoint
-        try await uploadToStrategy(strategy: strategy, data: data, contentType: contentType)
-
-        // 3. Confirm upload if required
-        if strategy.confirmRequired {
-            let storedFile = try await confirmUpload(
-                path: strategy.key,
-                size: data.count,
-                contentType: contentType
-            )
-            logger.debug("File uploaded with auto-generated key via presigned URL")
-            return storedFile
-        }
-
-        // For direct uploads without confirmation, fetch the file info
-        let files = try await list(options: ListOptions(prefix: strategy.key, limit: 1))
-        guard let storedFile = files.first else {
-            throw InsForgeError.httpError(statusCode: 404, message: "Uploaded file not found", error: nil, nextActions: nil)
-        }
-        logger.debug("File uploaded with auto-generated key")
-        return storedFile
     }
 
     /// Internal method to upload data to the strategy endpoint

--- a/Tests/InsForgeStorageTests/StorageObjectKeyTests.swift
+++ b/Tests/InsForgeStorageTests/StorageObjectKeyTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import InsForgeStorage
+
+/// Offline unit tests for client-side object key generation.
+///
+/// `upload(data:fileName:options:)` mints a unique, collision-free key
+/// client-side (`<sanitized-base>-<timestamp>-<random><ext>`) and uploads
+/// through the standard `upload(path:data:options:)` path. These tests run
+/// without a backend and are part of the deterministic CI suite.
+final class StorageObjectKeyTests: XCTestCase {
+    /// Keys follow `<sanitized-base>-<timestamp>-<random><ext>` and preserve the extension
+    func testGeneratedKeyPreservesExtensionAndBase() throws {
+        let key = StorageFileApi.generateObjectKey(from: "report.pdf")
+
+        let regex = try NSRegularExpression(pattern: "^report-\\d+-[a-z0-9]+\\.pdf$")
+        let range = NSRange(key.startIndex..., in: key)
+        XCTAssertNotNil(
+            regex.firstMatch(in: key, range: range),
+            "Key '\(key)' should match <base>-<timestamp>-<random>.pdf"
+        )
+    }
+
+    /// Characters outside [a-zA-Z0-9-_] in the base are replaced with '-'
+    func testGeneratedKeySanitizesSpecialCharacters() throws {
+        let key = StorageFileApi.generateObjectKey(from: "my photo (1).png")
+
+        XCTAssertTrue(key.hasSuffix(".png"))
+        let regex = try NSRegularExpression(pattern: "^my-photo--1--\\d+-[a-z0-9]+\\.png$")
+        let range = NSRange(key.startIndex..., in: key)
+        XCTAssertNotNil(
+            regex.firstMatch(in: key, range: range),
+            "Key '\(key)' should sanitize non-alphanumeric characters to '-'"
+        )
+    }
+
+    /// Long base names are truncated to 32 characters
+    func testGeneratedKeyTruncatesLongBase() {
+        let longBase = String(repeating: "a", count: 100)
+        let key = StorageFileApi.generateObjectKey(from: "\(longBase).txt")
+
+        XCTAssertTrue(key.hasPrefix(String(repeating: "a", count: 32) + "-"))
+        XCTAssertFalse(key.hasPrefix(String(repeating: "a", count: 33)))
+        XCTAssertTrue(key.hasSuffix(".txt"))
+    }
+
+    /// A filename without an extension gets no extension in the key
+    func testGeneratedKeyWithoutExtension() throws {
+        let key = StorageFileApi.generateObjectKey(from: "file")
+
+        let regex = try NSRegularExpression(pattern: "^file-\\d+-[a-z0-9]+$")
+        let range = NSRange(key.startIndex..., in: key)
+        XCTAssertNotNil(
+            regex.firstMatch(in: key, range: range),
+            "Key '\(key)' should have no extension"
+        )
+    }
+
+    /// A leading dot (dotfile) is treated as part of the base, not an extension
+    func testGeneratedKeyTreatsDotfileAsBase() throws {
+        let key = StorageFileApi.generateObjectKey(from: ".gitignore")
+
+        let regex = try NSRegularExpression(pattern: "^-gitignore-\\d+-[a-z0-9]+$")
+        let range = NSRange(key.startIndex..., in: key)
+        XCTAssertNotNil(
+            regex.firstMatch(in: key, range: range),
+            "Key '\(key)' should treat a dotfile name as the base"
+        )
+    }
+
+    /// An empty base falls back to 'file'
+    func testGeneratedKeyFallsBackToFileForEmptyBase() throws {
+        let key = StorageFileApi.generateObjectKey(from: "")
+
+        let regex = try NSRegularExpression(pattern: "^file-\\d+-[a-z0-9]+$")
+        let range = NSRange(key.startIndex..., in: key)
+        XCTAssertNotNil(
+            regex.firstMatch(in: key, range: range),
+            "Key '\(key)' should fall back to a 'file' base"
+        )
+    }
+
+    /// Repeated calls with the same filename produce distinct keys
+    func testGeneratedKeysAreUnique() {
+        let keys = (0..<50).map { _ in StorageFileApi.generateObjectKey(from: "avatar.jpg") }
+
+        XCTAssertEqual(Set(keys).count, keys.count, "Generated keys must be collision-free")
+        XCTAssertTrue(keys.allSatisfy { $0.hasPrefix("avatar-") && $0.hasSuffix(".jpg") })
+    }
+}


### PR DESCRIPTION
## Summary

Ports the storage changes from [InsForge-sdk-js v1.5.0](https://github.com/InsForge/InsForge-sdk-js/releases/tag/v1.5.0) (diff `v1.4.5..v1.5.0`) — **Storage: standard PUT create-or-replace semantics**, paired with the backend change InsForge/InsForge#1760.

## What was ported

- **`upload(path:data:options:)` / `upload(path:fileURL:options:)`** — uploading to a key that already exists now replaces the object in place (previously the server silently auto-renamed, e.g. `photo.png` → `photo (1).png`). This is a server-side behavior change; method signatures are unchanged. Doc comments updated to state the new semantics (mirrors the JS SDK, which only updated docs on `upload`).
- **`upload(data:fileName:options:)`** (the Swift equivalent of JS `uploadAuto`) — now mints a unique, collision-free key **client-side** (`<sanitized-base>-<timestamp>-<random><ext>`, base sanitized to `[a-zA-Z0-9-_]`, truncated to 32 chars, `file` fallback — same algorithm as the JS `generateObjectKey`) and delegates to the standard `upload(path:data:options:)` path. Without this, the raw filename would be treated as the literal key by the new backend and repeated auto-key uploads would silently overwrite each other.
- **Tests** — new offline `StorageObjectKeyTests` class (7 tests: ext/base preservation, sanitization, 32-char truncation, no-extension, dotfile, empty-name fallback, uniqueness), placed in a separate class so it runs in the deterministic `scripts/test-unit.sh` suite (the existing `InsForgeStorageTests` class is live-integration and skipped in CI).
- **Docs** — CHANGELOG `[Unreleased]` entry; README storage examples annotated with the new semantics.

## What was skipped and why

- JS `storage.test.ts` mock-fetch tests for `getPublicUrl` / `createSignedUrl` / `createSignedUrls` and the legacy-POST fallback — these cover JS-SDK methods that have no Swift counterpart and pre-existing JS behavior, not part of the v1.5.0 API contract change.
- `package.json` / lockfile / CI workflow / SDK-REFERENCE plumbing — JS-repo concerns.
- Version bump — this repo's version is bumped by `scripts/release.sh` at release time, so the changelog entry sits under `[Unreleased]`.

## Test results

- `swift build` — **passes** (Swift 6.3.3, macOS arm64).
- `./scripts/test-unit.sh` (XCTest) — **could not run locally**: this machine has only CommandLineTools (no Xcode), so the `XCTest` module is unavailable. This is a pre-existing toolchain limitation, not caused by these changes; the repo's CI (`macos-14` + full Xcode) will run the suite.
- As a substitute, the new test file was parse-checked with `swiftc -parse`, and a standalone harness was compiled against the **actual built `InsForgeStorage` module** (`@testable import`) exercising `generateObjectKey` with all 7 assertions from the new test class — **all pass** (e.g. `report.pdf` → `report-1784608265685-hfp8nn.pdf`, matching the JS `/^report-\d+-[a-z0-9]+\.pdf$/` contract).
- SwiftLint not installed locally; changes follow the repo's `.swiftlint.yml` conventions.

## Notes

- Requires an InsForge backend that includes the standard-PUT storage change (InsForge/InsForge#1760). Do not run against a pre-change backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs storage behavior with `InsForge-sdk-js` v1.5.0. Uploads now use standard PUT (create-or-replace), and auto-key uploads mint a unique client-side key to avoid overwrites. Requires backend with standard PUT storage (InsForge/InsForge#1760).

- **Refactors**
  - `upload(path:data:...)` and `upload(path:fileURL:...)` now replace existing objects in place (previously auto-renamed).
  - `upload(data:fileName:...)` now generates a unique key client-side (`<sanitized-base>-<timestamp>-<random><ext>`) and delegates to path-based upload.
  - Added offline unit tests for key generation; updated README and CHANGELOG.

- **Migration**
  - Ensure your backend includes InsForge/InsForge#1760.
  - If you relied on server auto-renaming, use `upload(data:fileName:...)` or provide unique paths.
  - No API signature changes.

<sup>Written for commit f2854f62642698cb5d8b0ce27f91b9dab5253c15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-swift/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

